### PR TITLE
refactor: adjust pydantic  models

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -4,7 +4,7 @@ from .base import BaseModel
 
 
 class ABIType(BaseModel):
-    name: str = None  # type: ignore  # NOTE: Tuples don't have names by default
+    name: Optional[str] = None  # NOTE: Tuples don't have names by default
     indexed: Optional[bool] = None  # Only event ABI types should have this field
     type: Union[str, "ABIType"]
     internalType: Optional[str] = None

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -4,7 +4,7 @@ from .base import BaseModel
 
 
 class ABIType(BaseModel):
-    name: str = ""  # NOTE: Tuples don't have names by default
+    name: str = None  # type: ignore  # NOTE: Tuples don't have names by default
     indexed: Optional[bool] = None  # Only event ABI types should have this field
     type: Union[str, "ABIType"]
     internalType: Optional[str] = None

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -55,12 +55,15 @@ class ContractType(BaseModel):
     deployment_bytecode: Optional[Bytecode] = Field(None, alias="deploymentBytecode")
     runtime_bytecode: Optional[Bytecode] = Field(None, alias="runtimeBytecode")
     # abi, userdoc and devdoc must conform to spec
-    abi: List[ABI] = None  # type: ignore
+    abi: Optional[List[ABI]] = None
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
 
     @property
     def constructor(self) -> Optional[ABI]:
+        if not self.abi:
+            return None
+
         for abi in self.abi:
             if abi.type == "constructor":
                 return abi
@@ -69,6 +72,9 @@ class ContractType(BaseModel):
 
     @property
     def fallback(self) -> Optional[ABI]:
+        if not self.abi:
+            return None
+
         for abi in self.abi:
             if abi.type == "fallback":
                 return abi
@@ -77,14 +83,23 @@ class ContractType(BaseModel):
 
     @property
     def events(self) -> List[ABI]:
+        if not self.abi:
+            return []
+
         return [abi for abi in self.abi if abi.type == "event"]
 
     @property
     def calls(self) -> List[ABI]:
+        if not self.abi:
+            return []
+
         return [abi for abi in self.abi if abi.type == "function" and not abi.is_stateful]
 
     @property
     def txns(self) -> List[ABI]:
+        if not self.abi:
+            return []
+
         return [abi for abi in self.abi if abi.type == "function" and abi.is_stateful]
 
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -55,7 +55,7 @@ class ContractType(BaseModel):
     deployment_bytecode: Optional[Bytecode] = Field(None, alias="deploymentBytecode")
     runtime_bytecode: Optional[Bytecode] = Field(None, alias="runtimeBytecode")
     # abi, userdoc and devdoc must conform to spec
-    abi: List[ABI] = []
+    abi: List[ABI] = None  # type: ignore
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
 

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -93,17 +93,16 @@ class PackageManifest(BaseModel):
 
     @root_validator
     def check_contract_source_ids(cls, values):
-        # TODO: FIX
-        # if (
-        #     "contract_types" in values
-        #     and values["contract_types"] is not None
-        #     and "sources" in values
-        #     and values["sources"] is not None
-        # ):
-        #     for alias in values["contract_types"]:
-        #         source_id = values["contract_types"][alias].source_id
-        #         if source_id and (source_id not in values["sources"]):
-        #             raise ValueError(f"'{source_id}' missing from `sources`")
+        if (
+            "contract_types" in values
+            and values["contract_types"] is not None
+            and "sources" in values
+            and values["sources"] is not None
+        ):
+            for alias in values["contract_types"]:
+                source_id = values["contract_types"][alias].source_id
+                if source_id and (source_id not in values["sources"]):
+                    raise ValueError(f"'{source_id}' missing from `sources`")
 
         return values
 

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -93,16 +93,17 @@ class PackageManifest(BaseModel):
 
     @root_validator
     def check_contract_source_ids(cls, values):
-        if (
-            "contract_types" in values
-            and values["contract_types"] is not None
-            and "sources" in values
-            and values["sources"] is not None
-        ):
-            for alias in values["contract_types"]:
-                source_id = values["contract_types"][alias].source_id
-                if source_id and (source_id not in values["sources"]):
-                    raise ValueError(f"'{source_id}' missing from `sources`")
+        # TODO: FIX
+        # if (
+        #     "contract_types" in values
+        #     and values["contract_types"] is not None
+        #     and "sources" in values
+        #     and values["sources"] is not None
+        # ):
+        #     for alias in values["contract_types"]:
+        #         source_id = values["contract_types"][alias].source_id
+        #         if source_id and (source_id not in values["sources"]):
+        #             raise ValueError(f"'{source_id}' missing from `sources`")
 
         return values
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,23 +11,8 @@ write_to = "ethpm_types/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py37', 'py38', 'py39']
 include = '\.pyi?$'
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-  | env
-  | venv
-)/
-'''
 
 [tool.pytest.ini_options]
 addopts = """
@@ -46,7 +31,7 @@ markers = "fuzzing: Run Hypothesis fuzz test suite"
 line_length = 100
 force_grid_wrap = 0
 include_trailing_comma = true
-known_third_party = ["hypothesis"]
+known_third_party = ["github", "hypothesis", "hypothesis_jsonschema", "pydantic", "pytest", "requests", "setuptools"]
 known_first_party = ["ethpm"]
 multi_line_output = 3
 use_parentheses = true

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,11 @@ extras_require = {
     "lint": [
         "black>=21.10b0,<22.0",  # auto-formatter and linter
         "mypy>=0.910,<1.0",  # Static type analyzer
+        "types-PyYAML",  # NOTE: Needed due to mypy typeshed
+        "types-requests",  # NOTE: Needed due to mypy typeshed
         "flake8>=3.9.2,<4.0",  # Style linter
+        "flake8-breakpoint>=1.1.0,<2.0.0",  # detect breakpoints left in code
+        "flake8-print>=4.0.0,<5.0.0",  # detect print statements left in code
         "isort>=5.9.3,<6.0",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,10 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
     ],
     "lint": [
-        "black>=20.8b1,<21.0",  # auto-formatter and linter
-        "mypy>=0.800,<1.0",  # Static type analyzer
-        "flake8>=3.8.3,<4.0",  # Style linter
-        "isort>=5.7.0,<6.0",  # Import sorting linter
+        "black>=21.10b0,<22.0",  # auto-formatter and linter
+        "mypy>=0.910,<1.0",  # Static type analyzer
+        "flake8>=3.9.2,<4.0",  # Style linter
+        "isort>=5.9.3,<6.0",  # Import sorting linter
     ],
     "release": [  # `release` GitHub Action job uses this
         "setuptools",  # Installation tool
@@ -59,7 +59,7 @@ setup(
         "importlib-metadata ; python_version<'3.8'",
         "pydantic>=1.8.2,<2.0.0",
     ],
-    python_requires=">=3.6,<4",
+    python_requires=">=3.7,<4",
     extras_require=extras_require,
     py_modules=["ethpm_types"],
     license="Apache-2.0",
@@ -68,14 +68,13 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={"ethpm": ["py.typed"]},
     classifiers=[
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Natural Language :: English",
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -7,7 +7,9 @@ from pydantic import ValidationError
 
 from ethpm_types import PackageManifest
 
-ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN")).get_repo("ethpm/ethpm-spec")
+ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get_repo(
+    "ethpm/ethpm-spec"
+)
 
 EXAMPLES_RAW_URL = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples"
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,5 @@
+import os
+
 import github
 import pytest  # type: ignore
 import requests  # type: ignore
@@ -5,7 +7,7 @@ from pydantic import ValidationError
 
 from ethpm_types import PackageManifest
 
-ETHPM_SPEC_REPO = github.Github().get_repo("ethpm/ethpm-spec")
+ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN")).get_repo("ethpm/ethpm-spec")
 
 EXAMPLES_RAW_URL = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples"
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,3 @@
-import os
-
 import github
 import pytest  # type: ignore
 import requests  # type: ignore
@@ -7,8 +5,7 @@ from pydantic import ValidationError
 
 from ethpm_types import PackageManifest
 
-# NOTE: Must export GITHUB_ACCESS_TOKEN
-ETHPM_SPEC_REPO = github.Github(os.environ["GITHUB_ACCESS_TOKEN"]).get_repo("ethpm/ethpm-spec")
+ETHPM_SPEC_REPO = github.Github().get_repo("ethpm/ethpm-spec")
 
 EXAMPLES_RAW_URL = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples"
 


### PR DESCRIPTION
### What I did

Updated pydantic models to work with Ape core.

Related issue: #

### How I did it

- refactor: `ABIType: name` and `ContractType: abi` to Optional so when calling dict they will not return empty keys
- refactor: `ContractType` properties to check for the existence of an`abi` list
- refactor: `pyproject.toml` to match updated repos
- refactor: `setup.py` for Beta and additional linting
- refactor: removed `GITHUB_ACCESSS_TOKEN` env var requirement, now optional

### How to verify it

Ran test suite for this repo and core

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
