### PR TITLE
refactor: change txns to transactions and doc strings

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -115,6 +115,12 @@ class SourceMap(BaseModel):
 
 
 class ContractType(BaseModel):
+    """
+    A serializable type representing the type of a contract.
+    For example, if you define your contract as ``contract MyContract`` (in Solidity),
+    then ``MyContract`` would be the type.
+    """
+
     _keep_fields_: Set[str] = {"abi"}
     _skip_fields_: Set[str] = {"name"}
     # NOTE: Field is optional if `ContractAlias` is the same as `ContractName`
@@ -130,6 +136,12 @@ class ContractType(BaseModel):
 
     @property
     def constructor(self) -> Optional[ABI]:
+        """
+        The constructor of the contract, if it has one. For example,
+        your smart-contract (in Solidity) may define a ``constructor() public {}``.
+        This property contains information about the parameters needed to initialize
+        a contract.
+        """
         if not self.abi:
             return None
 
@@ -141,6 +153,12 @@ class ContractType(BaseModel):
 
     @property
     def fallback(self) -> Optional[ABI]:
+        """
+        The fallback method of the contract, if it has one. A fallback method
+        is external, has no name, arguments, or return value, and gets invoked
+        when the user attempts to call a method that does not exist.
+        """
+
         if not self.abi:
             return None
 
@@ -152,6 +170,12 @@ class ContractType(BaseModel):
 
     @property
     def events(self) -> List[ABI]:
+        """
+        The events defined in a smart contract.
+        Returns:
+            List[:class:`~ethpm_types.abi.ABI`]
+        """
+
         if not self.abi:
             return []
 
@@ -159,13 +183,25 @@ class ContractType(BaseModel):
 
     @property
     def calls(self) -> List[ABI]:
+        """
+        The call-methods (read-only method, non-payable methods) defined in a smart contract.
+        Returns:
+            List[:class:`~ethpm_types.abi..ABI`]
+        """
+
         if not self.abi:
             return []
 
         return [abi for abi in self.abi if abi.type == "function" and not abi.is_stateful]
 
     @property
-    def txns(self) -> List[ABI]:
+    def transactions(self) -> List[ABI]:
+        """
+        The transaction-methods (stateful or payable methods) defined in a smart contract.
+        Returns:
+            List[:class:`~ethpm_types.abi..ABI`]
+        """
+
         if not self.abi:
             return []
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List, Optional, Set
+from typing import Iterator, List, Optional
 
 from pydantic import Field
 
@@ -121,15 +121,13 @@ class ContractType(BaseModel):
     then ``MyContract`` would be the type.
     """
 
-    _keep_fields_: Set[str] = {"abi"}
-    _skip_fields_: Set[str] = {"name"}
     # NOTE: Field is optional if `ContractAlias` is the same as `ContractName`
     name: Optional[str] = Field(None, alias="contractName")
     source_id: Optional[str] = Field(None, alias="sourceId")
     deployment_bytecode: Optional[Bytecode] = Field(None, alias="deploymentBytecode")
     runtime_bytecode: Optional[Bytecode] = Field(None, alias="runtimeBytecode")
     # abi, userdoc and devdoc must conform to spec
-    abi: Optional[List[ABI]] = None
+    abi: List[ABI] = []
     sourcemap: Optional[SourceMap] = None  # NOTE: Not a part of canonical EIP-2678 spec
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
@@ -142,8 +140,6 @@ class ContractType(BaseModel):
         This property contains information about the parameters needed to initialize
         a contract.
         """
-        if not self.abi:
-            return None
 
         for abi in self.abi:
             if abi.type == "constructor":
@@ -159,9 +155,6 @@ class ContractType(BaseModel):
         when the user attempts to call a method that does not exist.
         """
 
-        if not self.abi:
-            return None
-
         for abi in self.abi:
             if abi.type == "fallback":
                 return abi
@@ -176,9 +169,6 @@ class ContractType(BaseModel):
             List[:class:`~ethpm_types.abi.ABI`]
         """
 
-        if not self.abi:
-            return []
-
         return [abi for abi in self.abi if abi.type == "event"]
 
     @property
@@ -186,11 +176,8 @@ class ContractType(BaseModel):
         """
         The call-methods (read-only method, non-payable methods) defined in a smart contract.
         Returns:
-            List[:class:`~ethpm_types.abi..ABI`]
+            List[:class:`~ethpm_types.abi.ABI`]
         """
-
-        if not self.abi:
-            return []
 
         return [abi for abi in self.abi if abi.type == "function" and not abi.is_stateful]
 
@@ -199,11 +186,8 @@ class ContractType(BaseModel):
         """
         The transaction-methods (stateful or payable methods) defined in a smart contract.
         Returns:
-            List[:class:`~ethpm_types.abi..ABI`]
+            List[:class:`~ethpm_types.abi.ABI`]
         """
-
-        if not self.abi:
-            return []
 
         return [abi for abi in self.abi if abi.type == "function" and abi.is_stateful]
 


### PR DESCRIPTION
### What I did

Update `txns` back to match Ape core's `transactions`
Move over doc strings

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
