### PR TITLE
fix: correct 'indent' kwarg to 'separators' in base json method

### DIFF
--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -17,8 +17,8 @@ class BaseModel(_BaseModel):
         # NOTE: When serializing to IPFS, the canonical representation must be repeatable
 
         # EIP-2678: minified representation (at least by default)
-        if "indent" not in kwargs:
-            kwargs["indent"] = (",", ":")
+        if "separators" not in kwargs:
+            kwargs["separators"] = (",", ":")
 
         # EIP-2678: sort keys (at least by default)
         if "sort_keys" not in kwargs:


### PR DESCRIPTION
### What I did

Change 'indent' kwarg to 'separators' so the `.json()` method works correctly.

### How I did it

Noticed 'indent' was causing issues because of this default kwargument.
Realizing 'indent' needs to be None (which is the default: https://docs.python.org/3/library/json.html#json.dumps)
and we actually want separators here.

Thanks @fubuloubu for the help!

### How to verify it

Can now output JSON from a PackageManifest e.g. `manifest_file_path.write_text(dependency_manifest.json())`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
