### PR TITLE
refactor: introduce unions via discriminated literal fields

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,6 +1,11 @@
-from typing import List, Literal, Optional, Union
+from typing import List, Optional, Union
 
 from .base import BaseModel
+
+try:
+    from typing import Literal  # type: ignore
+except ImportError:
+    from typing_extensions import Literal  # type: ignore
 
 
 class ABIType(BaseModel):

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,11 +1,10 @@
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 from .base import BaseModel
 
 
 class ABIType(BaseModel):
     name: Optional[str] = None  # NOTE: Tuples don't have names by default
-    indexed: Optional[bool] = None  # Only event ABI types should have this field
     type: Union[str, "ABIType"]
     internalType: Optional[str] = None
 
@@ -18,64 +17,88 @@ class ABIType(BaseModel):
             # Recursively discover the canonical type
             return self.type.canonical_type
 
-
-def encode_arg(arg: ABIType) -> str:
-    encoded_arg = arg.canonical_type
-    # For events (handles both None and False conditions)
-    if arg.indexed:
-        encoded_arg += " indexed"
-    if arg.name:
-        encoded_arg += f" {arg.name}"
-    return encoded_arg
+    @property
+    def signature(self) -> str:
+        if self.name:
+            return f"{self.canonical_type} {self.name}"
+        else:
+            return self.canonical_type
 
 
-class ABI(BaseModel):
-    name: Optional[str] = None
-    inputs: Optional[List[ABIType]] = None
-    outputs: Optional[List[ABIType]] = None
-    # ABI v2 Field
-    # NOTE: Only functions have this field
-    stateMutability: Optional[str] = None
-    # NOTE: Only events have this field
-    anonymous: Optional[bool] = None
-    # TODO: Handle events and functions separately (maybe also default and constructor)
-    #       Would parse based on value of type here, so some indirection required
-    #       Might make most sense to add to ``ContractType`` as a serde extension
-    type: str
+class EventABIType(BaseModel):
+    name: Optional[str] = None  # NOTE: Tuples don't have names by default
+    indexed: bool = False  # Only event ABI types should have this field
+    type: Union[str, "ABIType"]
+    internalType: Optional[str] = None
+
+    @property
+    def canonical_type(self) -> str:
+        if isinstance(self.type, str):
+            return self.type
+
+        else:
+            # Recursively discover the canonical type
+            return self.type.canonical_type
 
     @property
     def signature(self) -> str:
-        """
-        String representing the function/event signature, which includes the arg names and types,
-        and output names (if any) and type(s)
-        """
-        name = self.name if (self.type == "function" or self.type == "event") else self.type
+        sig = self.canonical_type
+        # For events (handles both None and False conditions)
+        if self.indexed:
+            sig += " indexed"
+        if self.name:
+            sig += f" {self.name}"
+        return sig
 
-        input_args = ", ".join(map(encode_arg, self.inputs or []))
-        output_args = ""
 
-        if self.outputs:
-            output_args = " -> "
-            if len(self.outputs) > 1:
-                output_args += "(" + ", ".join(map(encode_arg, self.outputs)) + ")"
-            else:
-                output_args += encode_arg(self.outputs[0])
+class ConstructorABI(BaseModel):
+    type: Literal["constructor"]
 
-        return f"{name}({input_args}){output_args}"
+    # No `name` field
+    stateMutability: str = "nonpayable"  # NOTE: Should be either "payable" or "nonpayable"
+
+    inputs: List[ABIType] = []
+
+    @property
+    def is_payable(self) -> bool:
+        return self.stateMutability == "payable"
 
     @property
     def selector(self) -> str:
         """
-        String representing the function selector, used to compute ``method_id`` and ``event_id``.
+        String representing the function selector, used to compute ``method_id``.
         """
-        name = self.name if (self.type == "function" or self.type == "event") else self.type
         # NOTE: There is no space between input args for selector
-        input_names = ",".join(i.canonical_type for i in (self.inputs or []))
-        return f"{name}({input_names})"
+        input_names = ",".join(i.canonical_type for i in (self.inputs))
+        return f"{self.type}({input_names})"
+
+
+class FallbackABI(BaseModel):
+    type: Literal["fallback"]
+
+    # No `name` field
+    stateMutability: str = "nonpayable"  # NOTE: Should be either "payable" or "nonpayable"
 
     @property
-    def is_event(self) -> bool:
-        return self.anonymous is not None
+    def is_payable(self) -> bool:
+        return self.stateMutability == "payable"
+
+    @property
+    def selector(self) -> str:
+        """
+        String representing the function selector, used to compute ``method_id``.
+        """
+        return f"{self.type}()"
+
+
+class MethodABI(BaseModel):
+    type: Literal["function"]
+
+    name: str
+    stateMutability: str = "nonpayable"
+
+    inputs: List[ABIType] = []
+    outputs: List[ABIType] = []
 
     @property
     def is_payable(self) -> bool:
@@ -84,3 +107,60 @@ class ABI(BaseModel):
     @property
     def is_stateful(self) -> bool:
         return self.stateMutability not in ("view", "pure")
+
+    @property
+    def selector(self) -> str:
+        """
+        String representing the function selector, used to compute ``method_id`` and ``event_id``.
+        """
+        # NOTE: There is no space between input args for selector
+        input_names = ",".join(i.canonical_type for i in (self.inputs))
+        return f"{self.name}({input_names})"
+
+    @property
+    def signature(self) -> str:
+        """
+        String representing the function/event signature, which includes the arg names and types,
+        and output names (if any) and type(s)
+        """
+        input_args = ", ".join(i.signature for i in self.inputs)
+        output_args = ""
+
+        if self.outputs:
+            output_args = " -> "
+            if len(self.outputs) > 1:
+                output_args += "(" + ", ".join(o.canonical_type for o in self.outputs) + ")"
+
+            else:
+                output_args += self.outputs[0].canonical_type
+
+        return f"{self.name}({input_args}){output_args}"
+
+
+class EventABI(BaseModel):
+    type: Literal["event"]
+
+    name: str
+    inputs: List[EventABIType] = []
+    anonymous: bool = False
+
+    @property
+    def selector(self) -> str:
+        """
+        String representing the function selector, used to compute ``event_id``.
+        """
+        # NOTE: There is no space between input args for selector
+        input_names = ",".join(i.canonical_type for i in (self.inputs))
+        return f"{self.name}({input_names})"
+
+    @property
+    def signature(self) -> str:
+        """
+        String representing the function/event signature, which includes the arg names and types,
+        and output names (if any) and type(s)
+        """
+        input_args = ", ".join(i.signature for i in self.inputs)
+        return f"{self.name}({input_args})"
+
+
+ABI = Union[ConstructorABI, FallbackABI, MethodABI, EventABI]

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -30,20 +30,8 @@ class ABIType(BaseModel):
             return self.canonical_type
 
 
-class EventABIType(BaseModel):
-    name: Optional[str] = None  # NOTE: Tuples don't have names by default
+class EventABIType(ABIType):
     indexed: bool = False  # Only event ABI types should have this field
-    type: Union[str, "ABIType"]
-    internalType: Optional[str] = None
-
-    @property
-    def canonical_type(self) -> str:
-        if isinstance(self.type, str):
-            return self.type
-
-        else:
-            # Recursively discover the canonical type
-            return self.type.canonical_type
 
     @property
     def signature(self) -> str:

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -2,7 +2,7 @@ from typing import Iterator, List, Optional
 
 from pydantic import Field
 
-from .abi import ABI
+from .abi import ABI, ConstructorABI, EventABI, FallbackABI, MethodABI
 from .base import BaseModel
 from .utils import is_valid_hash
 
@@ -133,7 +133,7 @@ class ContractType(BaseModel):
     devdoc: Optional[dict] = None
 
     @property
-    def constructor(self) -> Optional[ABI]:
+    def constructor(self) -> Optional[ConstructorABI]:
         """
         The constructor of the contract, if it has one. For example,
         your smart-contract (in Solidity) may define a ``constructor() public {}``.
@@ -142,13 +142,13 @@ class ContractType(BaseModel):
         """
 
         for abi in self.abi:
-            if abi.type == "constructor":
+            if isinstance(abi, ConstructorABI):
                 return abi
 
         return None
 
     @property
-    def fallback(self) -> Optional[ABI]:
+    def fallback(self) -> Optional[FallbackABI]:
         """
         The fallback method of the contract, if it has one. A fallback method
         is external, has no name, arguments, or return value, and gets invoked
@@ -156,40 +156,40 @@ class ContractType(BaseModel):
         """
 
         for abi in self.abi:
-            if abi.type == "fallback":
+            if isinstance(abi, FallbackABI):
                 return abi
 
         return None
 
     @property
-    def events(self) -> List[ABI]:
+    def events(self) -> List[EventABI]:
         """
         The events defined in a smart contract.
         Returns:
             List[:class:`~ethpm_types.abi.ABI`]
         """
 
-        return [abi for abi in self.abi if abi.type == "event"]
+        return [abi for abi in self.abi if isinstance(abi, EventABI)]
 
     @property
-    def calls(self) -> List[ABI]:
+    def calls(self) -> List[MethodABI]:
         """
         The call-methods (read-only method, non-payable methods) defined in a smart contract.
         Returns:
             List[:class:`~ethpm_types.abi.ABI`]
         """
 
-        return [abi for abi in self.abi if abi.type == "function" and not abi.is_stateful]
+        return [abi for abi in self.abi if isinstance(abi, MethodABI) and not abi.is_stateful]
 
     @property
-    def transactions(self) -> List[ABI]:
+    def transactions(self) -> List[MethodABI]:
         """
         The transaction-methods (stateful or payable methods) defined in a smart contract.
         Returns:
             List[:class:`~ethpm_types.abi.ABI`]
         """
 
-        return [abi for abi in self.abi if abi.type == "function" and abi.is_stateful]
+        return [abi for abi in self.abi if isinstance(abi, MethodABI) and abi.is_stateful]
 
 
 class BIP122_URI(str):

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
+        "typing_extensions ; python_version<'3.8'",
         "pydantic>=1.8.2,<2.0.0",
     ],
     python_requires=">=3.7,<4",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -22,7 +22,8 @@ def test_examples(example_name):
     example = requests.get(f"{EXAMPLES_RAW_URL}/{example_name}/v3.json").json()
 
     if "invalid" not in example_name:
-        assert PackageManifest.parse_obj(example).dict() == example
+        package = PackageManifest.parse_obj(example)
+        assert package.dict() == example
 
     else:
         with pytest.raises((ValidationError, ValueError)):


### PR DESCRIPTION
### What I did
Introduce more type safety into this library

### How I did it
[Discriminated Unions](https://pydantic-docs.helpmanual.io/usage/types/#discriminated-unions-aka-tagged-unions)

### How to verify it
Tests pass... need to check with `ape`

### Checklist
- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
