### PR TITLE
refactor!: checksum operations into pure functions

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -5,7 +5,7 @@ from pydantic import Field
 
 from .abi import ABI, ConstructorABI, EventABI, FallbackABI, MethodABI
 from .base import BaseModel
-from .utils import is_valid_hash
+from .utils import Hex, is_valid_hex
 
 
 # TODO link references & link values are for solidity, not used with Vyper
@@ -23,7 +23,7 @@ class LinkReference(BaseModel):
 
 
 class Bytecode(BaseModel):
-    bytecode: Optional[str] = None
+    bytecode: Optional[Hex] = None
     linkReferences: Optional[List[LinkReference]] = None
     linkDependencies: Optional[List[LinkDependency]] = None
 
@@ -48,9 +48,9 @@ class Bytecode(BaseModel):
 
 class ContractInstance(BaseModel):
     contract_type: str = Field(..., alias="contractType")
-    address: str
-    transaction: Optional[str] = None
-    block: Optional[str] = None
+    address: Hex
+    transaction: Optional[Hex] = None
+    block: Optional[Hex] = None
     runtime_bytecode: Optional[Bytecode] = Field(None, alias="runtimeBytecode")
 
 
@@ -241,13 +241,13 @@ class BIP122_URI(str):
     @classmethod
     def validate_genesis_hash(cls, uri):
         genesis_hash, _, _ = uri.replace("blockchain://", "").split("/")
-        assert is_valid_hash(genesis_hash), f"hash is not valid: {genesis_hash}"
+        assert is_valid_hex("0x" + genesis_hash), f"hash is not valid: {genesis_hash}"
         assert len(genesis_hash) == 64, f"hash is not valid length: {genesis_hash}"
         return uri
 
     @classmethod
     def validate_block_hash(cls, uri):
         _, _, block_hash = uri.replace("blockchain://", "").split("/")
-        assert is_valid_hash(block_hash), f"hash is not valid: {block_hash}"
+        assert is_valid_hex("0x" + block_hash), f"hash is not valid: {block_hash}"
         assert len(block_hash) == 64, f"hash is not valid length: {block_hash}"
         return uri

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -242,10 +242,12 @@ class BIP122_URI(str):
     def validate_genesis_hash(cls, uri):
         genesis_hash, _, _ = uri.replace("blockchain://", "").split("/")
         assert is_valid_hash(genesis_hash), f"hash is not valid: {genesis_hash}"
+        assert len(genesis_hash) == 64, f"hash is not valid length: {genesis_hash}"
         return uri
 
     @classmethod
     def validate_block_hash(cls, uri):
         _, _, block_hash = uri.replace("blockchain://", "").split("/")
         assert is_valid_hash(block_hash), f"hash is not valid: {block_hash}"
+        assert len(block_hash) == 64, f"hash is not valid length: {block_hash}"
         return uri

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -239,7 +239,7 @@ class BIP122_URI(str):
 
         _, block_keyword, _ = uri.replace("blockchain://", "").split("/")
         if block_keyword != "block":
-            raise ValueError("must use block reference")
+            raise ValueError("Must use block reference.")
 
         return uri
 
@@ -247,10 +247,10 @@ class BIP122_URI(str):
     def validate_genesis_hash(cls, uri):
         genesis_hash, _, _ = uri.replace("blockchain://", "").split("/")
         if not is_valid_hex("0x" + genesis_hash):
-            raise ValueError(f"hash is not valid: {genesis_hash}")
+            raise ValueError(f"Hash is not valid: {genesis_hash}.")
 
         if len(genesis_hash) != 64:
-            raise ValueError(f"hash is not valid length: {genesis_hash}")
+            raise ValueError(f"Hash is not valid length: {genesis_hash}.")
 
         return uri
 
@@ -258,9 +258,9 @@ class BIP122_URI(str):
     def validate_block_hash(cls, uri):
         _, _, block_hash = uri.replace("blockchain://", "").split("/")
         if not is_valid_hex("0x" + block_hash):
-            raise ValueError(f"hash is not valid: {block_hash}")
+            raise ValueError(f"Hash is not valid: {block_hash}.")
 
         if len(block_hash) != 64:
-            raise ValueError(f"hash is not valid length: {block_hash}")
+            raise ValueError(f"Hash is not valid length: {block_hash}.")
 
         return uri

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -227,27 +227,40 @@ class BIP122_URI(str):
     def __get_validators__(cls):
         yield cls.validate_uri
         yield cls.validate_genesis_hash
+        yield cls.validate_block_hash
 
     @classmethod
     def validate_uri(cls, uri):
-        assert uri.startswith("blockchain://"), "Must use 'blockchain' protocol"
-        assert (
-            len(uri.replace("blockchain://", "").split("/")) == 3
-        ), "must be referenced via <genesis_hash>/block/<block_hash>"
+        if not uri.startswith("blockchain://"):
+            raise ValueError("Must use 'blockchain' protocol")
+
+        if len(uri.replace("blockchain://", "").split("/")) != 3:
+            raise ValueError("must be referenced via <genesis_hash>/block/<block_hash>")
+
         _, block_keyword, _ = uri.replace("blockchain://", "").split("/")
-        assert block_keyword == "block", "must use block reference"
+        if block_keyword != "block":
+            raise ValueError("must use block reference")
+
         return uri
 
     @classmethod
     def validate_genesis_hash(cls, uri):
         genesis_hash, _, _ = uri.replace("blockchain://", "").split("/")
-        assert is_valid_hex("0x" + genesis_hash), f"hash is not valid: {genesis_hash}"
-        assert len(genesis_hash) == 64, f"hash is not valid length: {genesis_hash}"
+        if not is_valid_hex("0x" + genesis_hash):
+            raise ValueError(f"hash is not valid: {genesis_hash}")
+
+        if len(genesis_hash) != 64:
+            raise ValueError(f"hash is not valid length: {genesis_hash}")
+
         return uri
 
     @classmethod
     def validate_block_hash(cls, uri):
         _, _, block_hash = uri.replace("blockchain://", "").split("/")
-        assert is_valid_hex("0x" + block_hash), f"hash is not valid: {block_hash}"
-        assert len(block_hash) == 64, f"hash is not valid length: {block_hash}"
+        if not is_valid_hex("0x" + block_hash):
+            raise ValueError(f"hash is not valid: {block_hash}")
+
+        if len(block_hash) != 64:
+            raise ValueError(f"hash is not valid length: {block_hash}")
+
         return uri

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -232,10 +232,10 @@ class BIP122_URI(str):
     @classmethod
     def validate_uri(cls, uri):
         if not uri.startswith("blockchain://"):
-            raise ValueError("Must use 'blockchain' protocol")
+            raise ValueError("Must use 'blockchain' protocol.")
 
         if len(uri.replace("blockchain://", "").split("/")) != 3:
-            raise ValueError("must be referenced via <genesis_hash>/block/<block_hash>")
+            raise ValueError("Must be referenced via <genesis_hash>/block/<block_hash>.")
 
         _, block_keyword, _ = uri.replace("blockchain://", "").split("/")
         if block_keyword != "block":

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -1,7 +1,8 @@
 from typing import Iterator, List, Optional
 
+from eth_utils import add_0x_prefix
 from hexbytes import HexBytes
-from pydantic import Field
+from pydantic import Field, validator
 
 from .abi import ABI, ConstructorABI, EventABI, FallbackABI, MethodABI
 from .base import BaseModel
@@ -26,6 +27,12 @@ class Bytecode(BaseModel):
     bytecode: Optional[Hex] = None
     linkReferences: Optional[List[LinkReference]] = None
     linkDependencies: Optional[List[LinkDependency]] = None
+
+    @validator("bytecode", pre=True)
+    def prefix_bytecode(cls, v):
+        if not v:
+            return None
+        return add_0x_prefix(v)
 
     def __repr__(self) -> str:
         self_str = super().__repr__()

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -4,7 +4,7 @@ from typing import List, Optional
 from pydantic import AnyUrl
 
 from .base import BaseModel
-from .utils import Algorithm, compute_checksum
+from .utils import Algorithm, Hex, compute_checksum
 
 
 class Compiler(BaseModel):
@@ -18,7 +18,7 @@ class Checksum(BaseModel):
     """Checksum information about the contents of a source file."""
 
     algorithm: Algorithm
-    hash: str
+    hash: Hex
 
 
 class Source(BaseModel):

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -56,7 +56,10 @@ class Source(BaseModel):
     # TODO: Add `SourceId` type and use instead of `str`
 
     def fetch_content(self) -> str:
-        """Loads resource at ``urls`` into ``content``."""
+        """Loads resource at ``urls`` into ``content`` if not available."""
+        # NOTE: This is a trapdoor to bypass fetching logic if already available
+        if self.content:
+            return self.content
 
         if len(self.urls) == 0:
             raise ValueError("No content to fetch.")

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -56,7 +56,14 @@ class Source(BaseModel):
     # TODO: Add `SourceId` type and use instead of `str`
 
     def fetch_content(self) -> str:
-        """Loads resource at ``urls`` into ``content`` if not available."""
+        """
+        Fetch the content for the given Source object.
+        Loads resource at ``urls`` into ``content`` if not available.
+
+        Returns:
+            str
+        """
+
         # NOTE: This is a trapdoor to bypass fetching logic if already available
         if self.content:
             return self.content
@@ -78,7 +85,15 @@ class Source(BaseModel):
     def calculate_checksum(self, algorithm: Algorithm = Algorithm.MD5) -> Checksum:
         """
         Compute the checksum of the ``Source`` object.
+        Will shortcircuit to content identifier if using content-addressed file references
         Fails if ``content`` isn't available locally or by fetching.
+
+        Args:
+            algorithm (`Optional[~ethpm_types.utils.Algorithm]`): The algorithm to use to compute
+              the checksum with. Defaults to MD5.
+
+        Returns:
+            :class:`~ethpm_types.source.Checksum`
         """
 
         # NOTE: Content-addressed URI schemes have checksum encoded directly in address.
@@ -95,7 +110,17 @@ class Source(BaseModel):
         )
 
     def content_is_valid(self) -> bool:
-        """Return if content is corrupted."""
+        """
+        Return if content is corrupted.
+        Will never be corrupted if content is locally available.
+        If content is referenced by content addressed identifier,
+        will not be corrupted either.
+        If referenced from a server URL,
+        then checksum must be present and will be validated against.
+
+        Returns:
+            bool
+        """
 
         # NOTE: Per EIP-2678, checksum is not needed if content does not need to be fetched
         if self.content:

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -24,26 +24,27 @@ class Checksum(BaseModel):
 class Source(BaseModel):
     """Information about a source file included in a Package Manifest."""
 
-    """Array of urls that resolve to the same source file."""
     urls: List[AnyUrl] = []
+    """Array of urls that resolve to the same source file."""
 
-    """Hash of the source file."""
     checksum: Optional[Checksum] = None
+    """Hash of the source file."""
 
-    """Inlined contract source."""
     content: Optional[str] = None
+    """Inlined contract source."""
 
-    """Filesystem path of source file."""
     installPath: Optional[str] = None
+    """Filesystem path of source file."""
     # NOTE: This was probably done for solidity, needs files cached to disk for compiling
     #       If processing a local project, code already exists, so no issue
     #       If processing remote project, cache them in ape project data folder
 
-    """The type of the source file."""
     type: Optional[str] = None
+    """The type of the source file."""
 
-    """The type of license associated with this source file."""
     license: Optional[str] = None
+    """The type of license associated with this source file."""
+
     # Set of `Source` objects that depend on this object
     # TODO: Add `SourceId` type and use instead of `str`
     references: Optional[List[str]] = None  # NOTE: Not a part of canonical EIP-2678 spec
@@ -52,6 +53,7 @@ class Source(BaseModel):
 
     def fetch_content(self) -> str:
         """Loads resource at ``urls`` into ``content``."""
+
         if len(self.urls) == 0:
             raise ValueError("No content to fetch.")
 
@@ -59,7 +61,7 @@ class Source(BaseModel):
         content = response.read().decode("utf-8")
 
         if self.content and self.content != content:
-            raise ValueError("Content mismatches stored.")
+            raise ValueError("Content mismatched stored value.")
 
         return content
 
@@ -83,6 +85,8 @@ class Source(BaseModel):
 
     @property
     def checksum_is_valid(self) -> bool:
+        """Return if checksum is valid or not."""
+
         if self.checksum:
             checksum = self.calculate_checksum(algorithm=self.checksum.algorithm)
 

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -80,3 +80,12 @@ class Source(BaseModel):
             hash=compute_checksum(content.encode("utf8"), algorithm=algorithm),
             algorithm=algorithm,
         )
+
+    @property
+    def checksum_is_valid(self) -> bool:
+        if self.checksum:
+            checksum = self.calculate_checksum(algorithm=self.checksum.algorithm)
+
+            return checksum == self.checksum
+
+        return False

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -50,26 +50,33 @@ class Source(BaseModel):
     # NOTE: Set of source objects that this object depends on
     imports: Optional[List[str]] = None  # NOTE: Not a part of canonical EIP-2678 spec
 
-    def load_content(self):
+    def fetch_content(self) -> str:
         """Loads resource at ``urls`` into ``content``."""
         if len(self.urls) == 0:
-            return
+            raise ValueError("No content to fetch.")
 
         response = urllib.request.urlopen(self.urls[0])
-        self.content = response.read().decode("utf-8")
+        content = response.read().decode("utf-8")
 
-    def compute_checksum(self, algorithm: Algorithm = Algorithm.MD5, force: bool = False):
+        if self.content and self.content != content:
+            raise ValueError("Content mismatches stored.")
+
+        return content
+
+    def calculate_checksum(self, algorithm: Algorithm = Algorithm.MD5) -> Checksum:
         """
-        Compute the checksum if ``content`` exists but ``checksum`` doesn't
-        exist yet. Or compute the checksum regardless if ``force`` is ``True``.
+        Compute the checksum of the ``Source`` object.
+        Fails if ``content`` isn't available locally or by fetching.
         """
-        if self.checksum and not force:
-            return  # skip recalculating
+        # TODO: If `self.urls` contains a content hash, return the decoded hash object (EIP-2678)
 
-        if not self.content:
-            raise ValueError("Content not loaded yet. Can't compute checksum.")
+        if self.content:
+            content = self.content
 
-        self.checksum = Checksum(  # type: ignore
-            hash=compute_checksum(self.content.encode("utf8"), algorithm=algorithm),
+        else:
+            content = self.fetch_content()
+
+        return Checksum(
+            hash=compute_checksum(content.encode("utf8"), algorithm=algorithm),
             algorithm=algorithm,
         )

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -28,7 +28,8 @@ class Source(BaseModel):
     """Array of urls that resolve to the same source file."""
 
     checksum: Optional[Checksum] = None
-    """Hash of the source file."""
+    """Hash of the source file. Per EIP-2678,
+    this field is only necessary if source must be fetched."""
 
     content: Optional[str] = None
     """Inlined contract source."""
@@ -45,11 +46,13 @@ class Source(BaseModel):
     license: Optional[str] = None
     """The type of license associated with this source file."""
 
-    # Set of `Source` objects that depend on this object
-    # TODO: Add `SourceId` type and use instead of `str`
     references: Optional[List[str]] = None  # NOTE: Not a part of canonical EIP-2678 spec
-    # NOTE: Set of source objects that this object depends on
+    """List of `Source` objects that depend on this object."""
+    # TODO: Add `SourceId` type and use instead of `str`
+
     imports: Optional[List[str]] = None  # NOTE: Not a part of canonical EIP-2678 spec
+    """List of source objects that this object depends on."""
+    # TODO: Add `SourceId` type and use instead of `str`
 
     def fetch_content(self) -> str:
         """Loads resource at ``urls`` into ``content``."""

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -1,6 +1,8 @@
 import urllib.request
 from typing import List, Optional
 
+from pydantic import AnyUrl
+
 from .base import BaseModel
 from .utils import Algorithm, compute_checksum
 
@@ -20,14 +22,27 @@ class Checksum(BaseModel):
 
 
 class Source(BaseModel):
+    """Information about a source file included in a Package Manifest."""
+
+    """Array of urls that resolve to the same source file."""
+    urls: List[AnyUrl] = []
+
+    """Hash of the source file."""
     checksum: Optional[Checksum] = None
-    urls: List[str] = []
+
+    """Inlined contract source."""
     content: Optional[str] = None
-    # TODO This was probably done for solidity, needs files cached to disk for compiling
-    # If processing a local project, code already exists, so no issue
-    # If processing remote project, cache them in ape project data folder
+
+    """Filesystem path of source file."""
     installPath: Optional[str] = None
+    # NOTE: This was probably done for solidity, needs files cached to disk for compiling
+    #       If processing a local project, code already exists, so no issue
+    #       If processing remote project, cache them in ape project data folder
+
+    """The type of the source file."""
     type: Optional[str] = None
+
+    """The type of license associated with this source file."""
     license: Optional[str] = None
     # Set of `Source` objects that depend on this object
     # TODO: Add `SourceId` type and use instead of `str`

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -2,7 +2,7 @@ import urllib.request
 from typing import List, Optional
 
 from .base import BaseModel
-from .utils import compute_checksum
+from .utils import Algorithm, compute_checksum
 
 
 class Compiler(BaseModel):
@@ -13,7 +13,9 @@ class Compiler(BaseModel):
 
 
 class Checksum(BaseModel):
-    algorithm: str
+    """Checksum information about the contents of a source file."""
+
+    algorithm: Algorithm
     hash: str
 
 
@@ -41,7 +43,7 @@ class Source(BaseModel):
         response = urllib.request.urlopen(self.urls[0])
         self.content = response.read().decode("utf-8")
 
-    def compute_checksum(self, algorithm: str = "md5", force: bool = False):
+    def compute_checksum(self, algorithm: Algorithm = Algorithm.MD5, force: bool = False):
         """
         Compute the checksum if ``content`` exists but ``checksum`` doesn't
         exist yet. Or compute the checksum regardless if ``force`` is ``True``.

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -83,9 +83,8 @@ class Source(BaseModel):
             algorithm=algorithm,
         )
 
-    @property
-    def checksum_is_valid(self) -> bool:
-        """Return if checksum is valid or not."""
+    def content_is_valid(self) -> bool:
+        """Return if content is corrupted."""
 
         if self.checksum:
             checksum = self.calculate_checksum(algorithm=self.checksum.algorithm)

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,9 +1,11 @@
 from enum import Enum
-from hashlib import md5
+from hashlib import md5, sha3_256, sha256
 
 
 class Algorithm(str, Enum):
     MD5 = "md5"
+    SHA3 = "sha3"
+    SHA256 = "sha256"
 
 
 def is_valid_hash(data: str) -> bool:
@@ -18,10 +20,13 @@ def is_valid_hash(data: str) -> bool:
 
 def compute_checksum(content: bytes, algorithm: Algorithm = Algorithm.MD5) -> str:
     if algorithm is Algorithm.MD5:
-        return md5(content).hexdigest()
 
-    # TODO: Support sha3
-    # TODO: Support sha256
+    elif algorithm is Algorithm.SHA3:
+        return sha3_256(content).hexdigest()
+
+    elif algorithm is Algorithm.SHA256:
+        return sha256(content).hexdigest()
+
     # TODO: Support IPFS CIDv0 & CIDv1
     # TODO: Support keccak256 (if even necessary, mentioned in EIP but not used)
     # TODO: Explore other algorithms needed

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,6 +1,8 @@
 from enum import Enum
 from hashlib import md5, sha3_256, sha256
 
+CONTENT_ADDRESSED_SCHEMES = {"ipfs"}
+
 
 class Algorithm(str, Enum):
     MD5 = "md5"

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -8,8 +8,11 @@ class Algorithm(str, Enum):
     SHA256 = "sha256"
 
 
-def is_valid_hash(data: str) -> bool:
-    if set(data.lower()) > set("1234567890abcdef"):
+def is_valid_hex(data: str) -> bool:
+    if not data.startswith("0x"):
+        return False
+
+    if set(data[2:].lower()) > set("1234567890abcdef"):
         return False
 
     if len(data) % 2 != 0:
@@ -18,14 +21,52 @@ def is_valid_hash(data: str) -> bool:
     return True
 
 
-def compute_checksum(content: bytes, algorithm: Algorithm = Algorithm.MD5) -> str:
+class Hex(str):
+    """A hex string value, typically from a hash."""
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        field_schema.update(
+            pattern="^0x([0-9a-f][0-9a-f])*$",
+            examples=[
+                "0x",  # empty bytes
+                "0xd4",
+                "0xd4e5",
+                "0xd4e56740",
+                "0xd4e56740f876aef8",
+                "0xd4e56740f876aef8c010b86a40d5f567",
+                "0xd4e56740f876aef8c010b86a40d5f56745a118d0906a34e69aec8c0db1cb8fa3",
+            ],
+        )
+
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate_hex
+
+    @classmethod
+    def validate_hex(cls, data: str) -> str:
+        if not is_valid_hex(data):
+            raise ValueError("Invalid Hex Value")
+
+        return data
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "Hex":
+        return cls("0x" + data.hex())
+
+    def to_bytes(self) -> bytes:
+        return bytes.fromhex(self[2:])
+
+
+def compute_checksum(content: bytes, algorithm: Algorithm = Algorithm.MD5) -> Hex:
     if algorithm is Algorithm.MD5:
+        return Hex.from_bytes(md5(content).digest())
 
     elif algorithm is Algorithm.SHA3:
-        return sha3_256(content).hexdigest()
+        return Hex.from_bytes(sha3_256(content).digest())
 
     elif algorithm is Algorithm.SHA256:
-        return sha256(content).hexdigest()
+        return Hex.from_bytes(sha256(content).digest())
 
     # TODO: Support IPFS CIDv0 & CIDv1
     # TODO: Support keccak256 (if even necessary, mentioned in EIP but not used)

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,13 +1,9 @@
+from enum import Enum
 from hashlib import md5
 
 
-def compute_checksum(source: bytes, algorithm: str = "md5") -> str:
-    if algorithm == "md5":
-        hasher = md5
-    else:
-        raise Exception("Unknown algorithm")
-
-    return hasher(source).hexdigest()
+class Algorithm(str, Enum):
+    MD5 = "md5"
 
 
 def is_valid_hash(data: str) -> bool:
@@ -18,3 +14,16 @@ def is_valid_hash(data: str) -> bool:
         return False
 
     return True
+
+
+def compute_checksum(content: bytes, algorithm: Algorithm = Algorithm.MD5) -> str:
+    if algorithm is Algorithm.MD5:
+        return md5(content).hexdigest()
+
+    # TODO: Support sha3
+    # TODO: Support sha256
+    # TODO: Support IPFS CIDv0 & CIDv1
+    # TODO: Support keccak256 (if even necessary, mentioned in EIP but not used)
+    # TODO: Explore other algorithms needed
+    else:
+        raise ValueError("Unsupported algorithm")

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "hexbytes>=0.2.2,<0.3",
         "pydantic>=1.8.2,<2.0.0",
         "eth-utils==1.10.0",
+        "py-cid>=0.3.0,<0.4.0",
     ],
     python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
         "typing_extensions ; python_version<'3.8'",
         "hexbytes>=0.2.2,<0.3",
         "pydantic>=1.8.2,<2.0.0",
+        "eth-utils==1.10.0",
     ],
     python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,

--- a/tests/test_corrupt_source.py
+++ b/tests/test_corrupt_source.py
@@ -1,0 +1,25 @@
+import pytest
+
+from ethpm_types.source import Source
+
+SOURCE_LOCATION = (
+    "https://github.com/OpenZeppelin/openzeppelin-contracts"
+    "/blob/master/contracts/token/ERC20/IERC20.sol"
+)
+
+
+@pytest.fixture
+def no_checksum() -> Source:
+    return Source.parse_obj({"urls": [SOURCE_LOCATION]})
+
+
+@pytest.fixture
+def bad_checksum() -> Source:
+    return Source.parse_obj(
+        {"urls": [SOURCE_LOCATION], "checksum": {"algorithm": "md5", "hash": "0x"}}
+    )
+
+
+def test_corrupt_source(bad_checksum, no_checksum):
+    assert not no_checksum.content_is_valid()
+    assert not bad_checksum.content_is_valid()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -31,6 +31,12 @@ def test_examples(example_name):
         # NOTE: Also make sure that the encoding is exactly the same (per EIP-2678)
         assert package.json() == example.text
 
+        if package.sources:
+            for source_name, source in package.sources.items():
+                # NOTE: Per EIP-2678, "Checksum is only required if content is missing"
+                if not source.content:
+                    assert source.content_is_valid(), f"Invalid checksum for '{source_name}'"
+
     else:
         with pytest.raises((ValidationError, ValueError)):
             PackageManifest.parse_obj(example_json).dict()
@@ -41,3 +47,9 @@ def test_open_zeppelin_contracts():
     manifest_dict = json.loads(oz_manifest_file.read_text())
     package = PackageManifest.parse_obj(manifest_dict)
     assert package.dict() == manifest_dict
+
+    if package.sources:
+        for source_name, source in package.sources.items():
+            # NOTE: Per EIP-2678, "Checksum is only required if content is missing"
+            if not source.content:
+                assert source.content_is_valid(), f"Invalid checksum for '{source_name}'"


### PR DESCRIPTION
### What I did
- Change the `algorithm` into a str enum type
- Add support for sha3 and sha256 algos
- Change `Source.load_content` and `Source.compute_checksum` mutating methods on `Source` to instead be pure functions derived from the information in `Source`
NOTE: This is a breaking change, and will require using the `Source` class slightly differently, including updating it with a new version of itself if you wish to store files in a different way than it may have originally specified. Also note that the content will still fetch itself when requested, but it is not no longer being updated in `Source` object (see previous note)
- Fix a bug with hash type sizes in BIP122 URI
- Added a property to verify checksum correctness
- Add a `Hex` type to further validate hex-encoded strings for addresses, blocks, transactions, checksums, and bytecode types
NOTE: This is somewhat a breaking change because now all hex types (except BIP122 URIs) must be prepended w/ `0x` (see changes to OpenZeppelin manifest). Should be interoperable as long as you purge any cached manifests.

fixes: #16
fixes" #18

### How I did it
Heavier use of Pydantic

### How to verify it
Validate changes required to `ape` core

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
