### PR TITLE
feat: structs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,11 +4,6 @@ repos:
     hooks:
     -   id: check-yaml
 
--   repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-    -   id: seed-isort-config
-
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.9.3
     hooks:

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,5 +1,7 @@
 from typing import List, Optional, Union
 
+from pydantic import Extra
+
 from .base import BaseModel
 
 try:
@@ -12,6 +14,9 @@ class ABIType(BaseModel):
     name: Optional[str] = None  # NOTE: Tuples don't have names by default
     type: Union[str, "ABIType"]
     internalType: Optional[str] = None
+
+    class Config:
+        extra = Extra.allow
 
     @property
     def canonical_type(self) -> str:
@@ -174,24 +179,14 @@ class EventABI(BaseModel):
         return f"{self.name}({input_args})"
 
 
-class StructABIType(ABIType):
-    offset: int
-
-    @property
-    def signature(self) -> str:
-        sig = self.canonical_type
-        if self.name:
-            sig += f" {self.name}"
-
-        return f"{sig} {self.offset}"
-
-
 class StructABI(BaseModel):
     type: Literal["struct"]
 
     name: str
-    members: List[StructABIType]
-    size: int
+    members: List[ABIType]
+
+    class Config:
+        extra = Extra.allow
 
     @property
     def selector(self) -> str:

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -125,7 +125,7 @@ class MethodABI(BaseModel):
         String representing the function selector, used to compute ``method_id``.
         """
         # NOTE: There is no space between input args for selector
-        input_names = ",".join(i.canonical_type for i in (self.inputs))
+        input_names = ",".join(i.canonical_type for i in self.inputs)
         return f"{self.name}({input_names})"
 
     @property
@@ -161,7 +161,7 @@ class EventABI(BaseModel):
         String representing the event selector, used to compute ``event_id``.
         """
         # NOTE: There is no space between input args for selector
-        input_names = ",".join(i.canonical_type for i in (self.inputs))
+        input_names = ",".join(i.canonical_type for i in self.inputs)
         return f"{self.name}({input_names})"
 
     @property
@@ -174,4 +174,42 @@ class EventABI(BaseModel):
         return f"{self.name}({input_args})"
 
 
-ABI = Union[ConstructorABI, FallbackABI, ReceiveABI, MethodABI, EventABI]
+class StructABIType(ABIType):
+    offset: int
+
+    @property
+    def signature(self) -> str:
+        sig = self.canonical_type
+        if self.name:
+            sig += f" {self.name}"
+
+        return f"{sig} {self.offset}"
+
+
+class StructABI(BaseModel):
+    type: Literal["struct"]
+
+    name: str
+    members: List[StructABIType]
+    size: int
+
+    @property
+    def selector(self) -> str:
+        """
+        String representing the struct selector.
+        """
+        # NOTE: There is no space between input args for selector
+        input_names = ",".join(i.canonical_type for i in self.members)
+        return f"{self.name}({input_names})"
+
+    @property
+    def signature(self) -> str:
+        """
+        String representing the struct signature, which includes the member names and types,
+        and offsets (if any) for display purposes only.
+        """
+        members_str = ", ".join(m.signature for m in self.members)
+        return f"{self.name}({members_str})"
+
+
+ABI = Union[ConstructorABI, FallbackABI, ReceiveABI, MethodABI, EventABI, StructABI]

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -13,7 +13,6 @@ except ImportError:
 class ABIType(BaseModel):
     name: Optional[str] = None  # NOTE: Tuples don't have names by default
     type: Union[str, "ABIType"]
-    internalType: Optional[str] = None
 
     class Config:
         extra = Extra.allow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,6 @@ markers = "fuzzing: Run Hypothesis fuzz test suite"
 line_length = 100
 force_grid_wrap = 0
 include_trailing_comma = true
-known_third_party = ["github", "hexbytes", "hypothesis", "hypothesis_jsonschema", "pydantic", "pytest", "requests", "setuptools"]
-known_first_party = ["ethpm_types"]
 multi_line_output = 3
 use_parentheses = true
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
     ],
     "lint": [
-        "black>=21.12b0,<22.0",  # auto-formatter and linter
+        "black>=22.3.0,<23.0",  # auto-formatter and linter
         "mypy>=0.910,<1.0",  # Static type analyzer
         "types-PyYAML",  # NOTE: Needed due to mypy typeshed
         "types-requests",  # NOTE: Needed due to mypy typeshed

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
     ],
     "lint": [
-        "black>=22.3.0,<23.0",  # auto-formatter and linter
-        "mypy>=0.941,<1.0",  # Static type analyzer
+        "black>=21.12b0,<22.0",  # auto-formatter and linter
+        "mypy>=0.910,<1.0",  # Static type analyzer
         "types-PyYAML",  # NOTE: Needed due to mypy typeshed
         "types-requests",  # NOTE: Needed due to mypy typeshed
         "flake8>=3.9.2,<4.0",  # Style linter

--- a/tests/test_cairo.py
+++ b/tests/test_cairo.py
@@ -1,0 +1,131 @@
+from ethpm_types import ContractType
+
+CAIRO_ERC20_ABI = [
+    {
+        "members": [
+            {"name": "low", "offset": 0, "type": "felt"},
+            {"name": "high", "offset": 1, "type": "felt"},
+        ],
+        "name": "Uint256",
+        "size": 2,
+        "type": "struct",
+    },
+    {
+        "inputs": [
+            {"name": "name", "type": "felt"},
+            {"name": "symbol", "type": "felt"},
+            {"name": "recipient", "type": "felt"},
+        ],
+        "name": "constructor",
+        "outputs": [],
+        "type": "constructor",
+    },
+    {
+        "inputs": [],
+        "name": "name",
+        "outputs": [{"name": "name", "type": "felt"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "symbol",
+        "outputs": [{"name": "symbol", "type": "felt"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "totalSupply",
+        "outputs": [{"name": "totalSupply", "type": "Uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [{"name": "decimals", "type": "felt"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "account", "type": "felt"}],
+        "name": "balanceOf",
+        "outputs": [{"name": "balance", "type": "Uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "owner", "type": "felt"}, {"name": "spender", "type": "felt"}],
+        "name": "allowance",
+        "outputs": [{"name": "remaining", "type": "Uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "recipient", "type": "felt"}, {"name": "amount", "type": "Uint256"}],
+        "name": "transfer",
+        "outputs": [{"name": "success", "type": "felt"}],
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"name": "sender", "type": "felt"},
+            {"name": "recipient", "type": "felt"},
+            {"name": "amount", "type": "Uint256"},
+        ],
+        "name": "transferFrom",
+        "outputs": [{"name": "success", "type": "felt"}],
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "spender", "type": "felt"}, {"name": "amount", "type": "Uint256"}],
+        "name": "approve",
+        "outputs": [{"name": "success", "type": "felt"}],
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "spender", "type": "felt"}, {"name": "added_value", "type": "Uint256"}],
+        "name": "increaseAllowance",
+        "outputs": [{"name": "success", "type": "felt"}],
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"name": "spender", "type": "felt"},
+            {"name": "subtracted_value", "type": "Uint256"},
+        ],
+        "name": "decreaseAllowance",
+        "outputs": [{"name": "success", "type": "felt"}],
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "recipient", "type": "felt"}, {"name": "amount", "type": "Uint256"}],
+        "name": "mint",
+        "outputs": [],
+        "type": "function",
+    },
+    {
+        "inputs": [{"name": "user", "type": "felt"}, {"name": "amount", "type": "Uint256"}],
+        "name": "burn",
+        "outputs": [],
+        "type": "function",
+    },
+]
+
+
+def test_cairo_abi():
+    abi = ContractType.parse_obj({"abi": CAIRO_ERC20_ABI}).abi
+
+    # Verify struct
+    struct = abi[0]
+    assert struct.type == "struct"
+    assert struct.size == 2
+    assert struct.members[0].name == "low"
+    assert struct.members[0].offset == 0
+    assert struct.members[1].name == "high"
+    assert struct.members[1].offset == 1
+
+    # Verify constructor
+    constructor = abi[1]
+    assert constructor.type == "constructor"

--- a/tests/test_cairo.py
+++ b/tests/test_cairo.py
@@ -115,17 +115,25 @@ CAIRO_ERC20_ABI = [
 
 
 def test_cairo_abi():
-    abi = ContractType.parse_obj({"abi": CAIRO_ERC20_ABI}).abi
+    contract_type = ContractType.parse_obj({"abi": CAIRO_ERC20_ABI})
+    abi = contract_type.abi
 
     # Verify struct
     struct = abi[0]
-    assert struct.type == "struct"
-    assert struct.size == 2
-    assert struct.members[0].name == "low"
-    assert struct.members[0].offset == 0
-    assert struct.members[1].name == "high"
-    assert struct.members[1].offset == 1
+    raw_struct = struct.dict()
+    assert struct.type == raw_struct["type"] == "struct"
+    assert struct.size == raw_struct["size"] == 2
+
+    struct_member_0 = struct.members[0]
+    raw_struct_member_0 = struct_member_0.dict()
+    struct_member_1 = struct.members[1]
+    raw_struct_member_1 = struct_member_1.dict()
+    assert struct_member_0.name == raw_struct_member_0["name"] == "low"
+    assert struct_member_0.offset == raw_struct_member_0["offset"] == 0
+    assert struct_member_1.name == raw_struct_member_1["name"] == "high"
+    assert struct_member_1.offset == raw_struct_member_1["offset"] == 1
 
     # Verify constructor
     constructor = abi[1]
-    assert constructor.type == "constructor"
+    constructor_raw = constructor.dict()
+    assert constructor.type == constructor_raw["type"] == "constructor"


### PR DESCRIPTION
### What I did

Adds `StructABI` and `StructABIType` to handle essential Starknet contracts.

### How I did it

Copied existing ABI methodologies and schema from Starknet.

### How to verify it

I added a test!
Question: Does this StructABI differ from Ethereum's?

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
