### PR TITLE
feat: add tuple components field to ABIType

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -14,6 +14,7 @@ class ABIType(BaseModel):
     name: Optional[str] = None  # NOTE: Tuples don't have names by default
     type: Union[str, "ABIType"]
     components: Optional[List["ABIType"]] = None  # NOTE: Tuples/Structs have this field
+    internalType: Optional[str] = None  # Some compilers insert this field, can have useful info
 
     class Config:
         extra = Extra.allow

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -13,13 +13,17 @@ except ImportError:
 class ABIType(BaseModel):
     name: Optional[str] = None  # NOTE: Tuples don't have names by default
     type: Union[str, "ABIType"]
+    components: Optional[List["ABIType"]] = None  # NOTE: Tuples/Structs have this field
 
     class Config:
         extra = Extra.allow
 
     @property
     def canonical_type(self) -> str:
-        if isinstance(self.type, str):
+        if self.type == "tuple" and self.components:  # NOTE: 2nd condition just to satisfy mypy
+            return f"({','.join(m.canonical_type for m in self.components)})"
+
+        elif isinstance(self.type, str):
             return self.type
 
         else:


### PR DESCRIPTION
### What I did

Tuple and Struct `ABIType` variables have additional member `components` that is currently unprocessed but important for ABI decoding purposes.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
