### PR TITLE
chore: support eth-utils 2.0 range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "typing_extensions ; python_version<'3.8'",
         "hexbytes>=0.2.2,<0.3",
         "pydantic>=1.8.2,<2.0.0",
-        "eth-utils==1.10.0",
+        "eth-utils>=1.10.0,<3.0",
         "py-cid>=0.3.0,<0.4.0",
     ],
     python_requires=">=3.7.2,<3.11",


### PR DESCRIPTION
### What I did

the public methods did not change in version 1 range to 2 range, and we are preparing to upgrade eth-dependencies in ape so we need this loosened first.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
