### PR TITLE
feat: hexbytes validation w/ pydantic

### DIFF
--- a/ethpm_types/__init__.py
+++ b/ethpm_types/__init__.py
@@ -1,15 +1,19 @@
 from .abi import ABI
+from .base import BaseModel
 from .contract_type import Bytecode, ContractInstance, ContractType
 from .manifest import PackageManifest, PackageMeta
 from .source import Checksum, Compiler, Source
+from .utils import HexBytes
 
 __all__ = [
     "ABI",
+    "BaseModel",
     "Bytecode",
     "Checksum",
     "Compiler",
     "ContractInstance",
     "ContractType",
+    "HexBytes",
     "PackageMeta",
     "PackageManifest",
     "Source",

--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -1,4 +1,8 @@
+from typing import Any, no_type_check
+
 from pydantic import BaseModel as _BaseModel
+
+from .utils import HexBytes
 
 
 class BaseModel(_BaseModel):
@@ -33,3 +37,31 @@ class BaseModel(_BaseModel):
             kwargs["exclude_none"] = True
 
         return super().json(*args, **kwargs)
+
+    @classmethod
+    @no_type_check
+    def _get_value(
+        cls,
+        v: Any,
+        to_dict: bool,
+        by_alias: bool,
+        include: Any,
+        exclude: Any,
+        exclude_unset: bool,
+        exclude_defaults: bool,
+        exclude_none: bool,
+    ) -> Any:
+
+        if isinstance(v, HexBytes):
+            return v.hex()
+
+        return super()._get_value(
+            v,
+            to_dict=to_dict,
+            by_alias=by_alias,
+            exclude_unset=exclude_unset,
+            exclude_defaults=exclude_defaults,
+            include=include,
+            exclude=exclude,
+            exclude_none=exclude_none,
+        )

--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -43,13 +43,8 @@ class BaseModel(_BaseModel):
     def _get_value(
         cls,
         v: Any,
-        to_dict: bool,
-        by_alias: bool,
-        include: Any,
-        exclude: Any,
-        exclude_unset: bool,
-        exclude_defaults: bool,
-        exclude_none: bool,
+        *args,
+        **kwargs,
     ) -> Any:
 
         if isinstance(v, HexBytes):
@@ -57,11 +52,6 @@ class BaseModel(_BaseModel):
 
         return super()._get_value(
             v,
-            to_dict=to_dict,
-            by_alias=by_alias,
-            exclude_unset=exclude_unset,
-            exclude_defaults=exclude_defaults,
-            include=include,
-            exclude=exclude,
-            exclude_none=exclude_none,
+            *args,
+            **kwargs,
         )

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,7 +1,19 @@
 from enum import Enum
 from hashlib import md5, sha3_256, sha256
 
+from hexbytes import HexBytes as BaseHexBytes
+
 CONTENT_ADDRESSED_SCHEMES = {"ipfs"}
+
+
+class HexBytes(BaseHexBytes):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        return HexBytes(v)
 
 
 class Algorithm(str, Enum):

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -1,0 +1,41 @@
+from ethpm_types import BaseModel, HexBytes
+
+TEST_MODEL_DICT = {
+    "byte_bytes": b"\x00",
+    "bytearray_bytes": bytearray([0]),
+    "str_bytes": "0x0",
+    "int_bytes": 0,
+    "bool_bytes": False,
+}
+
+
+class TestModel(BaseModel):
+    byte_bytes: HexBytes
+    bytearray_bytes: HexBytes
+    str_bytes: HexBytes
+    int_bytes: HexBytes
+    bool_bytes: HexBytes
+
+
+def test_hexbytes_dict():
+    test_model = TestModel.parse_obj(TEST_MODEL_DICT)
+    test_dict = test_model.dict()
+    assert len(test_dict) == 5
+
+    for _, v in test_dict.items():
+        assert v == "0x00"
+
+
+def test_hexbytes_dict_exclude():
+    test_model = TestModel.parse_obj(TEST_MODEL_DICT)
+
+    test_dict = test_model.dict(exclude={"byte_bytes"})
+    assert len(test_dict) == 4
+    assert "byte_bytes" not in test_dict.keys()
+
+
+def test_hexbytes_json():
+    test_model = TestModel.parse_obj(TEST_MODEL_DICT)
+    test_json = test_model.json(exclude={"bool_bytes", "byte_bytes", "int_bytes"})
+
+    assert test_json == '{"bytearray_bytes":"0x00","str_bytes":"0x00"}'

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -19,6 +19,10 @@ class TestModel(BaseModel):
 
 def test_hexbytes_dict():
     test_model = TestModel.parse_obj(TEST_MODEL_DICT)
+
+    for _, item in test_model.__fields__.items():
+        assert item.type_ == HexBytes
+
     test_dict = test_model.dict()
     assert len(test_dict) == 5
 

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -1,3 +1,5 @@
+from hexbytes import HexBytes as OriginalHexBytes
+
 from ethpm_types import BaseModel, HexBytes
 
 TEST_MODEL_DICT = {
@@ -6,6 +8,7 @@ TEST_MODEL_DICT = {
     "str_bytes": "0x0",
     "int_bytes": 0,
     "bool_bytes": False,
+    "original_bytes": OriginalHexBytes("0"),
 }
 
 
@@ -15,6 +18,7 @@ class TestModel(BaseModel):
     str_bytes: HexBytes
     int_bytes: HexBytes
     bool_bytes: HexBytes
+    original_bytes: HexBytes
 
 
 def test_hexbytes_dict():
@@ -24,7 +28,7 @@ def test_hexbytes_dict():
         assert item.type_ == HexBytes
 
     test_dict = test_model.dict()
-    assert len(test_dict) == 5
+    assert len(test_dict) == 6
 
     for _, v in test_dict.items():
         assert v == "0x00"
@@ -34,7 +38,7 @@ def test_hexbytes_dict_exclude():
     test_model = TestModel.parse_obj(TEST_MODEL_DICT)
 
     test_dict = test_model.dict(exclude={"byte_bytes"})
-    assert len(test_dict) == 4
+    assert len(test_dict) == 5
     assert "byte_bytes" not in test_dict.keys()
 
 
@@ -42,4 +46,4 @@ def test_hexbytes_json():
     test_model = TestModel.parse_obj(TEST_MODEL_DICT)
     test_json = test_model.json(exclude={"bool_bytes", "byte_bytes", "int_bytes"})
 
-    assert test_json == '{"bytearray_bytes":"0x00","str_bytes":"0x00"}'
+    assert test_json == '{"bytearray_bytes":"0x00","original_bytes":"0x00","str_bytes":"0x00"}'


### PR DESCRIPTION
### What I did
Whenever you wanted to use HexBytes as a type with a pydantic model you would get a validation error, now HexBytes can be validated and serialized on a pydantic model.

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #20 

### How I did it
Used the HexBytes class as a BaseModel, adding pydantic validation models
Used the Pydantic BaseModel class but specialized the `_get_value()` method to return `hex` when serializing.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
