### PR TITLE
feat: select methods and events by name, signature and keccak

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -279,21 +279,11 @@ class ContractType(BaseModel):
             selector_hash_fn=self._selector_hash_fn,
         )
 
-    @cached_property
-    def _selector_hash_fn(self) -> Optional[Callable[[str], bytes]]:
-        try:
-            from eth_utils import keccak
-            
-            def hasher(selector: str) -> bytes:
-                # keccak is the default on most ecosystems, other ecosystems can subclass to override it
-                return keccak(text=selector)
-                
-            return hasher
-            
-        except ImportError
-            warnings.warn("No backend installed for `keccak`, functionality degraded.")
-            return None
-        
+    def _selector_hash_fn(self, selector: str) -> bytes:
+        # keccak is the default on most ecosystems, other ecosystems can subclass to override it
+        from eth_utils import keccak
+
+        return keccak(text=selector)
 
 
 class BIP122_URI(str):

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -228,7 +228,7 @@ class ContractType(BaseModel):
         return ABIList(
             [abi for abi in self.abi if isinstance(abi, MethodABI) and not abi.is_stateful],
             selector_size=4,
-            selector_hash=lambda selector: keccak(text=selector),
+            selector_hash=self._selector_hash,
         )
 
     @property
@@ -242,7 +242,7 @@ class ContractType(BaseModel):
         return ABIList(
             [abi for abi in self.abi if isinstance(abi, MethodABI) and abi.is_stateful],
             selector_size=4,
-            selector_hash=lambda selector: keccak(text=selector),
+            selector_hash=self._selector_hash,
         )
 
     @property
@@ -255,8 +255,11 @@ class ContractType(BaseModel):
 
         return ABIList(
             [abi for abi in self.abi if isinstance(abi, EventABI)],
-            selector_hash=lambda selector: keccak(text=selector),
+            selector_hash=self._selector_hash,
         )
+
+    def _selector_hash(self, selector):
+        return keccak(text=selector)
 
 
 class BIP122_URI(str):

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -145,7 +145,7 @@ class ABIList(list):
         self._selector_hash = selector_hash
         super().__init__(iterable)
 
-    def __getitem__(self, item: Union[str, bytes]):  # type: ignore
+    def __getitem__(self, item: Union[str, bytes, MethodABI, EventABI]):  # type: ignore
         try:
             # selector
             if isinstance(item, str) and "(" in item:
@@ -161,19 +161,21 @@ class ABIList(list):
                     if self._selector_hash(abi.selector)[: self._selector_size]
                     == item[: self._selector_size]
                 )
+            elif isinstance(item, (MethodABI, EventABI)):
+                return next(abi for abi in self if abi.selector == item.selector)
         except StopIteration:
             raise KeyError(item)
 
         return super().__getitem__(item)  # type: ignore
 
     def __contains__(self, item: Union[str, bytes]) -> bool:  # type: ignore
+        if isinstance(item, (int, slice)):
+            return False
         try:
             self[item]
             return True
-        except KeyError:
+        except (KeyError, IndexError):
             return False
-        
-        return super().__contains__(item)  # type: ignore
 
 
 class ContractType(BaseModel):

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -154,6 +154,7 @@ class ABIList(list):
             elif isinstance(item, str):
                 return next(abi for abi in self if abi.name == item)
             # hashed selector, like log.topics[0] or tx.data
+            # NOTE: Will fail with `ImportError` if `item` is `bytes` and `eth-hash` has no backend
             elif isinstance(item, bytes) and self._selector_hash_fn:
                 return next(
                     abi

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -1,4 +1,4 @@
-from typing import Iterator, List, Optional, Union
+from typing import Callable, Iterator, List, Optional, Union
 
 from eth_utils import add_0x_prefix, keccak
 from hexbytes import HexBytes
@@ -134,7 +134,13 @@ class ABIList(list):
     Adds selection by name, selector and keccak(selector).
     """
 
-    def __init__(self, iterable=(), *, selector_size=32, selector_hash=None):
+    def __init__(
+        self,
+        iterable=(),
+        *,
+        selector_size=32,
+        selector_hash: Optional[Callable[[str], bytes]] = None,
+    ):
         self._selector_size = selector_size
         self._selector_hash = selector_hash
         super().__init__(iterable)
@@ -258,7 +264,7 @@ class ContractType(BaseModel):
             selector_hash=self._selector_hash,
         )
 
-    def _selector_hash(self, selector):
+    def _selector_hash(self, selector: str) -> bytes:
         return keccak(text=selector)
 
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -145,7 +145,7 @@ class ABIList(list):
         self._selector_hash_fn = selector_hash_fn
         super().__init__(iterable)
 
-    def __getitem__(self, item: Union[str, bytes, MethodABI, EventABI]):  # type: ignore
+    def __getitem__(self, item: Union[int, slice, str, bytes, MethodABI, EventABI]):  # type: ignore
         try:
             # selector
             if isinstance(item, str) and "(" in item:

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -146,20 +146,23 @@ class ABIList(list):
         super().__init__(iterable)
 
     def __getitem__(self, item: Union[str, bytes]):  # type: ignore
-        # selector
-        if isinstance(item, str) and "(" in item:
-            return next(abi for abi in self if abi.selector == item)
-        # name, could be ambiguous
-        elif isinstance(item, str):
-            return next(abi for abi in self if abi.name == item)
-        # hashed selector, like log.topics[0] or a tx.data
-        elif isinstance(item, bytes) and self._selector_hash:
-            return next(
-                abi
-                for abi in self
-                if self._selector_hash(abi.selector)[: self._selector_size]
-                == item[: self._selector_size]
-            )
+        try:
+            # selector
+            if isinstance(item, str) and "(" in item:
+                return next(abi for abi in self if abi.selector == item)
+            # name, could be ambiguous
+            elif isinstance(item, str):
+                return next(abi for abi in self if abi.name == item)
+            # hashed selector, like log.topics[0] or a tx.data
+            elif isinstance(item, bytes) and self._selector_hash:
+                return next(
+                    abi
+                    for abi in self
+                    if self._selector_hash(abi.selector)[: self._selector_size]
+                    == item[: self._selector_size]
+                )
+        except StopIteration:
+            raise KeyError(item)
 
         return super().__getitem__(item)  # type: ignore
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -279,9 +279,21 @@ class ContractType(BaseModel):
             selector_hash_fn=self._selector_hash_fn,
         )
 
-    def _selector_hash_fn(self, selector: str) -> bytes:
-        # keccak is the default on most ecosystems, other ecosystems can subclass to override it
-        return keccak(text=selector)
+    @cached_property
+    def _selector_hash_fn(self) -> Optional[Callable[[str], bytes]]:
+        try:
+            from eth_utils import keccak
+            
+            def hasher(selector: str) -> bytes:
+                # keccak is the default on most ecosystems, other ecosystems can subclass to override it
+                return keccak(text=selector)
+                
+            return hasher
+            
+        except ImportError
+            warnings.warn("No backend installed for `keccak`, functionality degraded.")
+            return None
+        
 
 
 class BIP122_URI(str):

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -1,6 +1,6 @@
 from typing import Callable, Iterator, List, Optional, Union
 
-from eth_utils import add_0x_prefix, keccak
+from eth_utils import add_0x_prefix
 from hexbytes import HexBytes
 from pydantic import Field, validator
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -166,6 +166,15 @@ class ABIList(list):
 
         return super().__getitem__(item)  # type: ignore
 
+    def __contains__(self, item: Union[str, bytes]) -> bool:  # type: ignore
+        try:
+            self[item]
+            return True
+        except KeyError:
+            return False
+        
+        return super().__contains__(item)  # type: ignore
+
 
 class ContractType(BaseModel):
     """

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -265,6 +265,7 @@ class ContractType(BaseModel):
         )
 
     def _selector_hash(self, selector: str) -> bytes:
+        # keccak is the default on most ecosystems, other ecosystems can subclass to override it
         return keccak(text=selector)
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ extras_require = {
         # Test-only deps
         "PyGithub>=1.54,<2.0",  # Necessary to pull official schema from github
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
+        "pysha3>=1.0.2,<2.0.0",  # Backend for eth-hash
     ],
     "lint": [
         "black>=22.3.0,<23.0",  # auto-formatter and linter
@@ -66,7 +67,6 @@ setup(
         "pydantic>=1.8.2,<2.0.0",
         "eth-utils>=1.10.0,<3.0",
         "py-cid>=0.3.0,<0.4.0",
-        "pysha3>=1.0.2,<2.0.0",
     ],
     python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "pydantic>=1.8.2,<2.0.0",
         "eth-utils>=1.10.0,<3.0",
         "py-cid>=0.3.0,<0.4.0",
+        "pysha3>=1.0.2,<2.0.0",
     ],
     python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

Added selection of method and event ABIs from lists returned by `mutable_methods`, `view_methods` and `events` by name, selector and keccak of selector.

### How I did it

Subclassed list and overriden `__getitem__`

### How to verify it

```python
selector = keccak(text='approve(address,uint256)')[:4]
contract_type.view_methods['balanceOf']
contract_type.mutable_methods['transfer']  # note: name may be ambiguous
contract_type.mutable_methods['approve(address,uint256)']
contract_type.mutable_methods[selector]
contract_type.mutable_methods[tx.data]

topic = keccak(text='Transfer(address,address,uint256)')
contract_type.events['Transfer']  # event names are not ambiguous
contract_type.events['Approval(address,address,uint256)']
contract_type.events[topic]
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
