### PR TITLE
feat: disallow mutation of abi type

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -18,6 +18,7 @@ class ABIType(BaseModel):
 
     class Config:
         extra = Extra.allow
+        allow_mutation = False
 
     @property
     def canonical_type(self) -> str:


### PR DESCRIPTION
### What I did

Disallowed mutation of `ABIType`, there is no reason to modify it after instantiation.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
