### PR TITLE
feat: add contract type back references to the ABI classes

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,6 +1,6 @@
-from typing import List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
-from pydantic import Extra
+from pydantic import Extra, Field
 
 from .base import BaseModel
 
@@ -8,6 +8,9 @@ try:
     from typing import Literal  # type: ignore
 except ImportError:
     from typing_extensions import Literal  # type: ignore
+
+if TYPE_CHECKING:
+    from ethpm_types.contract_type import ContractType
 
 
 class ABIType(BaseModel):
@@ -60,6 +63,7 @@ class EventABIType(ABIType):
 
 class ConstructorABI(BaseModel):
     type: Literal["constructor"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     # No `name` field
     stateMutability: str = "nonpayable"  # NOTE: Should be either "payable" or "nonpayable"
@@ -82,6 +86,7 @@ class ConstructorABI(BaseModel):
 
 class FallbackABI(BaseModel):
     type: Literal["fallback"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     # No `name` field
     stateMutability: str = "nonpayable"  # NOTE: Should be either "payable" or "nonpayable"
@@ -100,6 +105,7 @@ class FallbackABI(BaseModel):
 
 class ReceiveABI(BaseModel):
     type: Literal["receive"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     # No `name` field
     stateMutability: Literal["payable"]
@@ -118,6 +124,7 @@ class ReceiveABI(BaseModel):
 
 class MethodABI(BaseModel):
     type: Literal["function"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     name: str
     stateMutability: str = "nonpayable"
@@ -164,6 +171,7 @@ class MethodABI(BaseModel):
 
 class EventABI(BaseModel):
     type: Literal["event"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     name: str
     inputs: List[EventABIType] = []
@@ -190,6 +198,7 @@ class EventABI(BaseModel):
 
 class ErrorABI(BaseModel):
     type: Literal["error"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     name: str
     inputs: List[ABIType] = []
@@ -215,6 +224,7 @@ class ErrorABI(BaseModel):
 
 class StructABI(BaseModel):
     type: Literal["struct"]
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     name: str
     members: List[ABIType]
@@ -243,6 +253,7 @@ class StructABI(BaseModel):
 
 class UnprocessedABI(BaseModel):
     type: str
+    contract_type: Optional["ContractType"] = Field(None, exclude=True)
 
     class Config:
         extra = Extra.allow

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -16,6 +16,23 @@ ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get
 EXAMPLES_RAW_URL = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples"
 
 
+@pytest.fixture
+def oz_package_manifest_dict():
+    oz_manifest_file = Path(__file__).parent / "data" / "OpenZeppelinContracts.json"
+    return json.loads(oz_manifest_file.read_text())
+
+
+@pytest.fixture
+def oz_package(oz_package_manifest_dict):
+    return PackageManifest.parse_obj(oz_package_manifest_dict)
+
+
+@pytest.fixture
+def oz_contract_type(oz_package):
+    # NOTE: AccessControl has events, view methods, and mutable methods.
+    return oz_package.contract_types["AccessControl"]
+
+
 @pytest.mark.parametrize(
     "example_name",
     [f.name for f in ETHPM_SPEC_REPO.get_contents("examples")],  # type: ignore
@@ -42,14 +59,22 @@ def test_examples(example_name):
             PackageManifest.parse_obj(example_json).dict()
 
 
-def test_open_zeppelin_contracts():
-    oz_manifest_file = Path(__file__).parent / "data" / "OpenZeppelinContracts.json"
-    manifest_dict = json.loads(oz_manifest_file.read_text())
-    package = PackageManifest.parse_obj(manifest_dict)
-    assert package.dict() == manifest_dict
+def test_open_zeppelin_contracts(oz_package, oz_package_manifest_dict):
+    assert oz_package.dict() == oz_package_manifest_dict
 
-    if package.sources:
-        for source_name, source in package.sources.items():
-            # NOTE: Per EIP-2678, "Checksum is only required if content is missing"
-            if not source.content:
-                assert source.content_is_valid(), f"Invalid checksum for '{source_name}'"
+    for source_name, source in oz_package.sources.items():
+        # NOTE: Per EIP-2678, "Checksum is only required if content is missing"
+        if not source.content:
+            assert source.content_is_valid(), f"Invalid checksum for '{source_name}'"
+
+
+def test_contract_type_backrefs(oz_contract_type):
+    assert oz_contract_type.events, "setup: Test contract should have events"
+    assert oz_contract_type.view_methods, "setup: Test contract should have view methods"
+    assert oz_contract_type.mutable_methods, "setup: Test contract should have mutable methods"
+
+    assert oz_contract_type.constructor.contract_type == oz_contract_type
+    assert oz_contract_type.fallback.contract_type == oz_contract_type
+    assert all(e.contract_type == oz_contract_type for e in oz_contract_type.events)
+    assert all(m.contract_type == oz_contract_type for m in oz_contract_type.mutable_methods)
+    assert all(m.contract_type == oz_contract_type for m in oz_contract_type.view_methods)


### PR DESCRIPTION
### What I did

This allows ABIs to be able to reference other parts of their ABIs if needed, such as Cairo lang structs types used in Methods.

The contact types are optional so that you can still attempt to use ABIs without coming from a parsed `ContractType` class.

### How I did it

* Add excluded fields to the models representing optional contract type back-refs
* Set the contract types values when getting from contract type class

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
