### PR TITLE
feat: ignore contract type in repr for ABI

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -113,7 +113,7 @@ class ConstructorABI(BaseModel):
     type: Literal["constructor"]
     """The value ``"constructor"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -158,7 +158,7 @@ class FallbackABI(BaseModel):
     type: Literal["fallback"]
     """The value ``"fallback"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -196,7 +196,7 @@ class ReceiveABI(BaseModel):
     type: Literal["receive"]
     """The value ``"receive"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -230,7 +230,7 @@ class MethodABI(BaseModel):
     type: Literal["function"]
     """The value ``"function"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -309,7 +309,7 @@ class EventABI(BaseModel):
     type: Literal["event"]
     """The value ``"event"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -353,7 +353,7 @@ class ErrorABI(BaseModel):
     type: Literal["error"]
     """The value ``"error"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -395,7 +395,7 @@ class StructABI(BaseModel):
     type: Literal["struct"]
     """The value ``"struct"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.
@@ -440,7 +440,7 @@ class UnprocessedABI(BaseModel):
     type: str
     """The type name as a string."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True)
+    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
     """
     A reference to this ABI's contract type. This gets set during ``ContractType``
     deserialization.

--- a/tests/test_solidity_and_vyper.py
+++ b/tests/test_solidity_and_vyper.py
@@ -148,3 +148,15 @@ def test_select_by_name_contains(vyper_contract):
     assert "NumberChange(uint256,uint256)" in contract_type.events
     assert keccak(text="NumberChange(uint256,uint256)") in contract_type.events
     assert keccak(text="MadeUpEvent(uint64)") not in contract_type.events
+
+
+def test_contract_type_excluded_in_repr_abi(vyper_contract):
+    contract_type = ContractType.parse_obj(vyper_contract)
+    actual = repr(contract_type.events[0])
+    assert "contract_type" not in actual
+
+    actual = repr(contract_type.mutable_methods[0])
+    assert "contract_type" not in actual
+
+    actual = repr(contract_type.view_methods[0])
+    assert "contract_type" not in actual


### PR DESCRIPTION
### What I did

Ignores the `contract_type` back reference for ABI classes

### How I did it

`repr=False`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
