### PR TITLE
chore: add requests install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
         "pydantic>=1.8.2,<2.0.0",
         "eth-utils>=1.10.0,<3.0",
         "py-cid>=0.3.0,<0.4.0",
+        "requests>=2.28.1,<3",
     ],
     python_requires=">=3.7.2,<3.11",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

While working on evm-trace, I installed ethpm-types and got an error running tests. The requests library isn't installed as part of this package, even though it used throughout.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
