### PR TITLE
chore: bump settings sync with ape

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -21,7 +21,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[release]
-        
+
     - name: Build
       run: python setup.py sdist bdist_wheel
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.971
     hooks:
     -   id: mypy
-        additional_dependencies: [types-PyYAML, types-requests]
+        additional_dependencies: [types-requests]
 
 
 default_language_version:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.2.0
     hooks:
     -   id: check-yaml
 
@@ -24,7 +24,7 @@ repos:
     rev: v0.971
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-PyYAML, types-requests]
 
 
 default_language_version:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ extras_require = {
         "twine",  # Package upload tool
     ],
     "dev": [
-        "commitizen>=2.19,<2.20",  # Manage commits and publishing releases
+        "commitizen",  # Manage commits and publishing releases
         "pre-commit",  # Ensure that linters are run prior to committing
         "pytest-watch",  # `ptw` test watcher/runner
         "IPython",  # Console for interacting
@@ -76,7 +76,7 @@ setup(
         "py-cid>=0.3.0,<0.4",
         "requests>=2.28.1,<3",
     ],
-    python_requires=">=3.7.2,<3.11",
+    python_requires=">=3.7.2,<4",
     extras_require=extras_require,
     py_modules=["ethpm_types"],
     license="Apache-2.0",


### PR DESCRIPTION
### What I did

Aligns settings but also a PR to generate a new release and figure out why 0.3.6 is unreachable.


### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
