### PR TITLE
feat: add ContractType.pcmap

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -206,6 +206,13 @@ class SourceMap(BaseModel):
 
 
 class PCMapItem(BaseModel):
+    """
+    Line information for a given EVM instruction.
+
+    These are utilized in the pc-map by which the compiler generates source code spans for given
+    program counter positions.
+    """
+
     line_start: Optional[int] = None
     column_start: Optional[int] = None
     line_end: Optional[int] = None
@@ -222,7 +229,7 @@ class PCMap(BaseModel):
     variables and their uses.
     """
 
-    __root__: Dict[str, List[int]]
+    __root__: Dict[str, Optional[List[Optional[int]]]]
 
     def parse(self) -> Dict[int, PCMapItem]:
         """

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -139,6 +139,7 @@ class SourceMap(BaseModel):
     """
     As part of the AST output, the compiler provides the range of the source code
     that is represented by the respective node in the AST.
+
     This can be used for various purposes ranging from static analysis tools that
     report errors based on the AST and debugging tools that highlight local variables
     and their uses.
@@ -205,7 +206,6 @@ class SourceMap(BaseModel):
 
 
 class PCMapItem(BaseModel):
-    pc: int
     line_start: Optional[int]
     column_start: Optional[int]
     line_end: Optional[int]
@@ -213,9 +213,25 @@ class PCMapItem(BaseModel):
 
 
 class PCMap(BaseModel):
+    """
+    As part of the source output, the compiler provides the a map of program counter values to the
+    spans of source code that
+
+    This can be used for various purposes ranging from static analysis tools that
+    report errors based on the program counter value and debugging tools that highlight local
+    variables and their uses.
+    """
+
     __root__: Dict[str, List[int]]
 
     def parse(self) -> Dict[int, PCMapItem]:
+        """
+        Parses the pc map string into a map of ``PCMapItem`` items, using integer pc values as keys.
+
+        The format from the compiler will have numeric string keys with lists of ints for values.
+        These integers represent (in order) the starting line, starting column, ending line, and
+        ending column numbers.
+        """
         return {
             int(key): PCMapItem.construct(
                 line_start=value[0],
@@ -317,16 +333,6 @@ class ContractType(BaseModel):
     """
     The program counter map representing which lines in the source code account for which
     instructions in the bytecode.
-
-    The compiler returns the information as string PC keys with list values. The values in the list
-    represent the starting line, starting column, ending line, and ending column of the relevant
-    statement in the source code.
-
-    Format Example::
-            {
-                "123": [1, 2, 1, 4],
-                ...,
-            }
 
     **NOTE**: This is not part of the canonical EIP-2678 spec.
     """

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -204,6 +204,29 @@ class SourceMap(BaseModel):
             yield item
 
 
+class PCMapItem(BaseModel):
+    pc: int
+    line_start: Optional[int]
+    column_start: Optional[int]
+    line_end: Optional[int]
+    column_end: Optional[int]
+
+
+class PCMap(BaseModel):
+    __root__: dict[str, list[int]]
+
+    def parse(self) -> dict[int, PCMapItem]:
+        return {
+            int(key): PCMapItem.construct(
+                line_start=value[0],
+                column_start=value[1],
+                line_end=value[2],
+                column_end=value[3],
+            )
+            for key, value in self.__root__.items()
+        }
+
+
 class ABIList(list):
     """
     Adds selection by name, selector and keccak(selector).
@@ -290,10 +313,21 @@ class ContractType(BaseModel):
     **NOTE**: This is not part of the canonical EIP-2678 spec.
     """
 
-    pcmap: Optional[dict] = None
+    pcmap: Optional[PCMap] = None
     """
     The program counter map representing which lines in the source code account for which
     instructions in the bytecode.
+
+    The compiler returns the information as string PC keys with list values. The values in the list
+    represent the starting line, starting column, ending line, and ending column of the relevant
+    statement in the source code.
+
+    Format Example::
+            {
+                "123": [1, 2, 1, 4],
+                ...,
+            }
+
     **NOTE**: This is not part of the canonical EIP-2678 spec.
     """
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -247,7 +247,7 @@ class PCMap(BaseModel):
 
             results[int(key)] = result
 
-        return result
+        return results
 
 
 class ABIList(list):

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -214,8 +214,8 @@ class PCMapItem(BaseModel):
 
 class PCMap(BaseModel):
     """
-    As part of the source output, the compiler provides the a map of program counter values to the
-    spans of source code that
+    As part of the source output, the compiler provides a map of program counter values to
+    statements in the source code that the instructions were compiled from.
 
     This can be used for various purposes ranging from static analysis tools that
     report errors based on the program counter value and debugging tools that highlight local

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -294,6 +294,7 @@ class ContractType(BaseModel):
     """
     The program counter map representing which lines in the source code account for which
     instructions in the bytecode.
+    **NOTE**: This is not part of the canonical EIP-2678 spec.
     """
 
     userdoc: Optional[dict] = None

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterator, List, Optional, Union
+from typing import Callable, Dict, Iterator, List, Optional, Union
 
 from eth_utils import add_0x_prefix
 from hexbytes import HexBytes
@@ -213,9 +213,9 @@ class PCMapItem(BaseModel):
 
 
 class PCMap(BaseModel):
-    __root__: dict[str, list[int]]
+    __root__: Dict[str, List[int]]
 
-    def parse(self) -> dict[int, PCMapItem]:
+    def parse(self) -> Dict[int, PCMapItem]:
         return {
             int(key): PCMapItem.construct(
                 line_start=value[0],

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -206,10 +206,10 @@ class SourceMap(BaseModel):
 
 
 class PCMapItem(BaseModel):
-    line_start: Optional[int]
-    column_start: Optional[int]
-    line_end: Optional[int]
-    column_end: Optional[int]
+    line_start: Optional[int] = None
+    column_start: Optional[int] = None
+    line_end: Optional[int] = None
+    column_end: Optional[int] = None
 
 
 class PCMap(BaseModel):
@@ -232,15 +232,22 @@ class PCMap(BaseModel):
         These integers represent (in order) the starting line, starting column, ending line, and
         ending column numbers.
         """
-        return {
-            int(key): PCMapItem.construct(
-                line_start=value[0],
-                column_start=value[1],
-                line_end=value[2],
-                column_end=value[3],
-            )
-            for key, value in self.__root__.items()
-        }
+        results = {}
+
+        for key, value in self.__root__.items():
+            if value is not None:
+                result = PCMapItem(
+                    line_start=value[0],
+                    column_start=value[1],
+                    line_end=value[2],
+                    column_end=value[3],
+                )
+            else:
+                result = PCMapItem()
+
+            results[int(key)] = result
+
+        return result
 
 
 class ABIList(list):
@@ -329,7 +336,7 @@ class ContractType(BaseModel):
     **NOTE**: This is not part of the canonical EIP-2678 spec.
     """
 
-    pcmap: Optional[PCMap] = None
+    pcmap: Optional[Dict[str, PCMapItem]] = None
     """
     The program counter map representing which lines in the source code account for which
     instructions in the bytecode.

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -290,6 +290,12 @@ class ContractType(BaseModel):
     **NOTE**: This is not part of the canonical EIP-2678 spec.
     """
 
+    pcmap: Optional[dict] = None
+    """
+    The program counter map representing which lines in the source code account for which
+    instructions in the bytecode.
+    """
+
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
 

--- a/tests/test_pc_map.py
+++ b/tests/test_pc_map.py
@@ -17,11 +17,7 @@ def test_pc_map_valid():
 def test_pc_map_empty_line_info():
     """
     Test the parsing of a pc-map from a compiler's output that has empty line
-    information:
-
-            {
-                    "186": [None, None, None, None],
-            }
+    information.
     """
     pcmap = PCMap.parse_obj({"186": [None, None, None, None]}).parse()
 
@@ -37,11 +33,7 @@ def test_pc_map_empty_line_info():
 def test_pc_map_missing_line_info():
     """
     Test the parsing of a pc-map from a compiler's output that is entirely missing line
-    information:
-
-            {
-                    "186": None,
-            }
+    information.
     """
     pcmap = PCMap.parse_obj({"186": None}).parse()
 

--- a/tests/test_pc_map.py
+++ b/tests/test_pc_map.py
@@ -1,5 +1,3 @@
-import pytest
-
 from ethpm_types.contract_type import PCMap, PCMapItem
 
 

--- a/tests/test_pc_map.py
+++ b/tests/test_pc_map.py
@@ -1,0 +1,65 @@
+import pytest
+
+from ethpm_types.contract_type import PCMap, PCMapItem
+
+
+def test_pc_map_valid():
+    """
+    Test the parsing of a valid pc-map from a compiler's output.
+    """
+    pcmap = PCMap.parse_obj({"186": [10, 20, 10, 40]}).parse()
+
+    keys = list(pcmap.keys())
+
+    assert len(keys) == 1
+    assert keys[0] == 186
+    assert pcmap[186] == PCMapItem(line_start=10, column_start=20, line_end=10, column_end=40)
+
+
+def test_pc_map_empty_line_info():
+    """
+    Test the parsing of a pc-map from a compiler's output that has empty line
+    information:
+
+            {
+                    "186": [None, None, None, None],
+            }
+    """
+    pcmap = PCMap.parse_obj({"186": [None, None, None, None]}).parse()
+
+    keys = list(pcmap.keys())
+
+    assert len(keys) == 1
+    assert keys[0] == 186
+    assert pcmap[186] == PCMapItem(
+        line_start=None, column_start=None, line_end=None, column_end=None
+    )
+
+
+def test_pc_map_missing_line_info():
+    """
+    Test the parsing of a pc-map from a compiler's output that is entirely missing line
+    information:
+
+            {
+                    "186": None,
+            }
+    """
+    pcmap = PCMap.parse_obj({"186": None}).parse()
+
+    keys = list(pcmap.keys())
+
+    assert len(keys) == 1
+    assert keys[0] == 186
+    assert pcmap[186] == PCMapItem(
+        line_start=None, column_start=None, line_end=None, column_end=None
+    )
+
+
+def test_pc_map_empty():
+    """
+    Test the parsing of an empty pc-map from a compiler's output.
+    """
+    pcmap = PCMap.parse_obj({}).parse()
+
+    assert pcmap == {}


### PR DESCRIPTION
Looks like I'm going to need this for the reverts work

We have `sourcemap` but that's for the AST specifically, and it's much easier to query `pc_pos_map[trace_frame.pc]`

Open to suggestions for the field naming and documentation!