### PR TITLE
fix: allow empty-string content

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -102,7 +102,7 @@ class Source(BaseModel):
         """
 
         # NOTE: This is a trapdoor to bypass fetching logic if already available
-        if self.content:
+        if self.content is not None:
             return self.content
 
         if len(self.urls) == 0:
@@ -160,7 +160,7 @@ class Source(BaseModel):
         """
 
         # NOTE: Per EIP-2678, checksum is not needed if content does not need to be fetched
-        if self.content:
+        if self.content is not None:
             return True
 
         # NOTE: Per EIP-2678, Checksum is not required if a URL is content addressed.

--- a/tests/test_corrupt_source.py
+++ b/tests/test_corrupt_source.py
@@ -20,6 +20,16 @@ def bad_checksum() -> Source:
     )
 
 
+@pytest.fixture
+def empty_source() -> Source:
+    return Source.parse_obj({"content": ""})
+
+
 def test_corrupt_source(bad_checksum, no_checksum):
     assert not no_checksum.content_is_valid()
     assert not bad_checksum.content_is_valid()
+
+
+def test_empty_source(empty_source):
+    assert empty_source.fetch_content() == ""
+    assert empty_source.content_is_valid()


### PR DESCRIPTION
### What I did

Allow `Source.content` to be `""`, and only disallow `None`

fixes: #48

### How I did it

Change content checks to check for `None`. If we happen to read in a source file that's empty, it's still a valid file but won't have content. Previously the conditional would cause it to fail and, since the source did not also have `urls`, would result in a `ValueError`

### How to verify it

A test project with at least one empty source should be testable, and not throw the `ValueError` about missing content

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
