### PR TITLE
feat: add ContractType.dev_messages

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -351,6 +351,13 @@ class ContractType(BaseModel):
     **NOTE**: This is not part of the canonical EIP-2678 spec.
     """
 
+    dev_messages: Optional[Dict[int, str]] = None
+    """
+    A map of dev-message comments in the source contract by their starting line number.
+
+    **NOTE**: This is not part of the canonical EIP-2678 spec.
+    """
+
     userdoc: Optional[dict] = None
     devdoc: Optional[dict] = None
 


### PR DESCRIPTION
### What I did

Adds `dev_messages` map to `ContractType` to facilitate dev-message assertions in ape-core

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
