### PR TITLE
fix: make `selector` a property on `ConstructorABI`

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -143,6 +143,7 @@ class ConstructorABI(BaseModel):
         input_args = ", ".join(i.signature for i in self.inputs)
         return f"constructor({input_args})"
 
+    @property
     def selector(self) -> str:
         """
         String representing the constructor selector.

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -6,4 +6,4 @@ def test_constructor_selector():
         type="constructor",
         inputs=[ABIType(name="contract_address", type="address", internalType="address")],
     )
-    assert constructor.selector() == "constructor(address)"
+    assert constructor.selector == "constructor(address)"


### PR DESCRIPTION
### What I did

Some how did not realize this. UGH!

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
