### PR TITLE
fix: issue where could not use FileUrl in a manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 22.12.0
     hooks:
       - id: black
         name: black
@@ -24,7 +24,7 @@ repos:
     rev: v0.991
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-requests, types-setuptools]
 
 
 default_language_version:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.991
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ def get_versions() -> List[str]:
     versions = [
         d.name
         for d in build_dir.iterdir()
-        if d.is_dir and pattern.match(d.stem) and "beta" not in d.name and "alpha" not in d.name
+        if d.is_dir() and pattern.match(d.stem) and "beta" not in d.name and "alpha" not in d.name
     ]
 
     return versions

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -1,10 +1,11 @@
 from typing import Dict, List, Optional
 
-from pydantic import AnyUrl, Field, root_validator, validator
+from pydantic import Field, root_validator, validator
 
 from .base import BaseModel
 from .contract_type import BIP122_URI, ContractInstance, ContractType
 from .source import Compiler, Source
+from .utils import AnyUrl
 
 ALPHABET = set("abcdefghijklmnopqrstuvwxyz")
 NUMBERS = set("0123456789")

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -2,10 +2,9 @@ from typing import List, Optional
 
 import requests
 from cid import make_cid  # type: ignore
-from pydantic import AnyUrl
 
 from .base import BaseModel
-from .utils import CONTENT_ADDRESSED_SCHEMES, Algorithm, Hex, compute_checksum
+from .utils import CONTENT_ADDRESSED_SCHEMES, Algorithm, AnyUrl, Hex, compute_checksum
 
 
 class Compiler(BaseModel):

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,9 +1,13 @@
 from enum import Enum
 from hashlib import md5, sha3_256, sha256
+from typing import Union
 
 from hexbytes import HexBytes as BaseHexBytes
+from pydantic import AnyUrl as _AnyUrl
+from pydantic import FileUrl
 
 CONTENT_ADDRESSED_SCHEMES = {"ipfs"}
+AnyUrl = Union[_AnyUrl, FileUrl]
 
 
 class HexBytes(BaseHexBytes):

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ extras_require = {
         "pysha3>=1.0.2,<2.0.0",  # Backend for eth-hash
     ],
     "lint": [
-        "black>=22.10.0",  # auto-formatter and linter
-        "mypy==0.982",  # Static type analyzer
-        "types-PyYAML",  # NOTE: Needed due to mypy typeshed
-        "types-requests",  # NOTE: Needed due to mypy typeshed
-        "flake8>=5.0.4",  # Style linter
+        "black>=22.12.0",  # auto-formatter and linter
+        "mypy==0.991",  # Static type analyzer
+        "types-setuptools",  # Needed due to mypy typeshed
+        "types-requests",  # Needed due to mypy typeshed
+        "types-" "flake8>=5.0.4",  # Style linter
         "flake8-breakpoint>=1.1.0",  # detect breakpoints left in code
         "flake8-print>=4.0.0",  # detect print statements left in code
         "isort>=5.10.1",  # Import sorting linter

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "mypy==0.991",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
-        "types-" "flake8>=5.0.4",  # Style linter
+        "flake8>=5.0.4",  # Style linter
         "flake8-breakpoint>=1.1.0",  # detect breakpoints left in code
         "flake8-print>=4.0.0",  # detect print statements left in code
         "isort>=5.10.1",  # Import sorting linter

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -47,3 +47,10 @@ def test_open_zeppelin_contracts(oz_package, oz_package_manifest_dict):
         # NOTE: Per EIP-2678, "Checksum is only required if content is missing"
         if not source.content:
             assert source.content_is_valid(), f"Invalid checksum for '{source_name}'"
+
+
+def test_file_bases_dependency_url():
+    manifest = PackageManifest(
+        buildDependencies={"test-package": "file:///path/to/manifest/test-package.json"}
+    )
+    assert manifest.dependencies["test-package"] == "file:///path/to/manifest/test-package.json"


### PR DESCRIPTION
### What I did

For some reaosn, `FileUrl` format fails pydantic validation for `AnyUrl`
Simple example:

```python
from pydantic import FileUrl, AnyUrl, BaseModel
from typing import Union


class GenericModel(BaseModel):
    v: AnyUrl  # Failure case 


class FileModel(BaseModel):
    v: FileUrl


class DontCareModel(BaseModel):
    v: Union[AnyUrl, FileUrl]


value = 'file:///foo/bar'
try:
    # This don't work on files for some reason
    GenericModel(v=value)  # Fails
except Exception as err:
    print(err)

model = FileModel(v=value)
assert model.v == value

test_model = DontCareModel(v=value)
assert model.v == value
print("success!")
```

### How I did it

Redefine as `AnyUrl = Union[_AnyUrl, FileUrl]`

### How to verify it

Can now have file URL in manifest. See tests.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
