### PR TITLE
feat: add method that gets method

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -518,6 +518,24 @@ class ContractType(BaseModel):
             selector_hash_fn=self._selector_hash_fn,
         )
 
+    def get_method(self, selector: Union[int, str, bytes]) -> Optional[MethodABI]:
+        """
+        Get the method from this contract type with the given selector.
+
+        Args:
+            selector (Union[int, str, bytes]): The method ID selector.
+
+        Returns:
+            Optional[MethodABI]: The method, if found. Else ``None``.
+        """
+
+        if selector in self.mutable_methods:
+            return self.mutable_methods[selector]
+        elif selector in self.view_methods:
+            return self.view_methods[selector]
+
+        return None
+
     def _selector_hash_fn(self, selector: str) -> bytes:
         # keccak is the default on most ecosystems, other ecosystems can subclass to override it
         from eth_utils import keccak

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -518,23 +518,17 @@ class ContractType(BaseModel):
             selector_hash_fn=self._selector_hash_fn,
         )
 
-    def get_method(self, selector: Union[int, str, bytes]) -> Optional[MethodABI]:
-        """
-        Get the method from this contract type with the given selector.
+    @property
+    def methods(self) -> ABIList:
+        method_abis = [abi for abi in self.abi if isinstance(abi, MethodABI)]
+        for abi in method_abis:
+            abi.contract_type = self
 
-        Args:
-            selector (Union[int, str, bytes]): The method ID selector.
-
-        Returns:
-            Optional[MethodABI]: The method, if found. Else ``None``.
-        """
-
-        if selector in self.mutable_methods:
-            return self.mutable_methods[selector]
-        elif selector in self.view_methods:
-            return self.view_methods[selector]
-
-        return None
+        return ABIList(
+            method_abis,
+            selector_id_size=4,
+            selector_hash_fn=self._selector_hash_fn,
+        )
 
     def _selector_hash_fn(self, selector: str) -> bytes:
         # keccak is the default on most ecosystems, other ecosystems can subclass to override it

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -224,12 +224,12 @@ def test_contract_type_backrefs(oz_contract_type):
 @view_selector_parametrization
 def test_get_view_method(selector, vyper_contract):
     contract_type = ContractType.parse_obj(vyper_contract)
-    method_abi = contract_type.get_method(selector)
+    method_abi = contract_type.methods[selector]
     assert method_abi.selector == "getStruct()"
 
 
 @mutable_selector_parametrization
 def test_get_mutable_method(selector, vyper_contract):
     contract_type = ContractType.parse_obj(vyper_contract)
-    method_abi = contract_type.get_method(selector)
+    method_abi = contract_type.methods[selector]
     assert method_abi.selector == "setNumber(uint256)"

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -222,14 +222,14 @@ def test_contract_type_backrefs(oz_contract_type):
 
 
 @view_selector_parametrization
-def test_get_view_method(selector, vyper_contract):
+def test_select_view_method_from_all_methods(selector, vyper_contract):
     contract_type = ContractType.parse_obj(vyper_contract)
     method_abi = contract_type.methods[selector]
     assert method_abi.selector == "getStruct()"
 
 
 @mutable_selector_parametrization
-def test_get_mutable_method(selector, vyper_contract):
+def test_select_mutable_method_from_all_methods(selector, vyper_contract):
     contract_type = ContractType.parse_obj(vyper_contract)
     method_abi = contract_type.methods[selector]
     assert method_abi.selector == "setNumber(uint256)"


### PR DESCRIPTION
### What I did

This would simplify some things in the Ape framework.
Need a way to search for any method, whether it is mutable or view, in one spot.
This is useful for building up reports about methods, such as traces or gas reports.

### How I did it

Add `methods` property that iterated through both but it was an `ABIList` so you could do `contract_type.methods[selector]`.

### How to verify it

See tests, as always.
It is highly enumerated there.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
