### PR TITLE
feat!: `sourcemap` repr, str, docs and fixes

### DIFF
--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -7,7 +7,7 @@ from .utils import HexBytes
 
 class BaseModel(_BaseModel):
     def dict(self, *args, **kwargs) -> dict:
-        # NOTE: We do this to accomodate the aliases needed for EIP-2678 compatibility
+        # NOTE: We do this to accommodate the aliases needed for EIP-2678 compatibility
         if "by_alias" not in kwargs:
             kwargs["by_alias"] = True
 
@@ -28,7 +28,7 @@ class BaseModel(_BaseModel):
         if "sort_keys" not in kwargs:
             kwargs["sort_keys"] = True
 
-        # NOTE: We do this to accomodate the aliases needed for EIP-2678 compatibility
+        # NOTE: We do this to accommodate the aliases needed for EIP-2678 compatibility
         if "by_alias" not in kwargs:
             kwargs["by_alias"] = True
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -159,12 +159,11 @@ class SourceMap(BaseModel):
 
         item = None
 
-        def extract_sourcemap_item(expanded_row, item_idx, previous_val=None):
-            if len(expanded_row) > item_idx and expanded_row[item_idx] != "":
-                return expanded_row[item_idx]
+        def extract_sourcemap_item(_expanded_row, item_idx, previous_val=None):
+            if len(_expanded_row) > item_idx and _expanded_row[item_idx] != "":
+                return _expanded_row[item_idx]
 
-            else:
-                return previous_val  # Use previous item (or None if no previous item)
+            return previous_val  # Use previous item (or None if no previous item)
 
         for i, row in enumerate(self.__root__.strip().split(";")):
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -139,7 +139,7 @@ class SourceMapItem(BaseModel):
     The byte-offset start of the range in the source file.
     """
 
-    stop: Optional[int]
+    length: Optional[int]
     """
     The byte-offset length.
     """
@@ -206,13 +206,13 @@ class SourceMap(BaseModel):
 
                 if item is None:
                     start = int(extract_sourcemap_item(expanded_row, 0) or -1)
-                    stop = int(extract_sourcemap_item(expanded_row, 1) or -1)
+                    length = int(extract_sourcemap_item(expanded_row, 1) or -1)
                     contract_id = int(extract_sourcemap_item(expanded_row, 2) or -1)
                     jump_code = extract_sourcemap_item(expanded_row, 3) or ""
 
                 else:
                     start = int(extract_sourcemap_item(expanded_row, 0, item.start or -1))
-                    stop = int(extract_sourcemap_item(expanded_row, 1, item.stop or -1))
+                    length = int(extract_sourcemap_item(expanded_row, 1, item.length or -1))
                     contract_id = int(
                         extract_sourcemap_item(expanded_row, 2, item.contract_id or -1)
                     )
@@ -221,7 +221,7 @@ class SourceMap(BaseModel):
                 item = SourceMapItem.construct(
                     # NOTE: `-1` for these three entries means `None`
                     start=start if start != -1 else None,
-                    stop=stop if stop != -1 else None,
+                    length=length if length != -1 else None,
                     contract_id=contract_id if contract_id != -1 else None,
                     jump_code=jump_code,
                 )

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -151,7 +151,7 @@ class SourceMapItem(BaseModel):
 
     jump_code: str
     """
-    An identifier for whether a jump goes into a function, returns from a function, 
+    An identifier for whether a jump goes into a function, returns from a function,
     or is part of a loop.
     """
     # NOTE: ignore "modifier_depth" keyword introduced in solidity >0.6.x

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -174,8 +174,8 @@ class SourceMap(BaseModel):
     def __repr__(self) -> str:
         return self.__root__
 
-    # def __str__(self) -> str:
-    #     return self.__root__
+    def __str__(self) -> str:
+        return self.__root__
 
     def parse(self) -> Iterator[SourceMapItem]:
         """

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -151,8 +151,8 @@ class SourceMapItem(BaseModel):
 
     jump_code: str
     """
-    An identifier indicating whether a jump indicator goes into a function,
-    returns from a function, or is part of a loop.
+    An identifier for whether a jump goes into a function, returns from a function, 
+    or is part of a loop.
     """
     # NOTE: ignore "modifier_depth" keyword introduced in solidity >0.6.x
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -138,8 +138,8 @@ class SourceMapItem(BaseModel):
 
 class SourceMap(BaseModel):
     """
-    As part of the AST output, the compiler provides the range of the source code
-    that is represented by the respective node in the AST.
+    As part of the Abstract Syntax Tree (AST) output, the compiler provides the range
+    of the source code that is represented by the respective node in the AST.
 
     This can be used for various purposes ranging from static analysis tools that
     report errors based on the AST and debugging tools that highlight local variables

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -128,11 +128,32 @@ class ContractInstance(BaseModel):
 
 
 class SourceMapItem(BaseModel):
+    """
+    An object modeling a node in a source map; useful for mapping
+    the source map string back to source code.
+    """
+
     # NOTE: `None` entry means this path was inserted by the compiler during codegen
     start: Optional[int]
+    """
+    The byte-offset start of the range in the source file.
+    """
+
     stop: Optional[int]
+    """
+    The byte-offset length.
+    """
+
     contract_id: Optional[int]
+    """
+    The source identifier.
+    """
+
     jump_code: str
+    """
+    An identifier indicating whether a jump indicator goes into a function,
+    returns from a function, or is part of a loop.
+    """
     # NOTE: ignore "modifier_depth" keyword introduced in solidity >0.6.x
 
 
@@ -173,7 +194,10 @@ class SourceMap(BaseModel):
             if len(_expanded_row) > item_idx and _expanded_row[item_idx] != "":
                 return _expanded_row[item_idx]
 
-            return previous_val  # Use previous item (or None if no previous item)
+            # Use previous item (or None if no previous item).
+            # This is because sourcemaps are compressed to save space,
+            # and this is one of the compression-rules.
+            return previous_val
 
         for i, row in enumerate(self.__root__.strip().split(";")):
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -150,6 +150,12 @@ class SourceMap(BaseModel):
 
     __root__: str
 
+    def __repr__(self) -> str:
+        return self.__root__
+
+    def __str__(self) -> str:
+        return self.__root__
+
     def parse(self) -> Iterator[SourceMapItem]:
         """
         Parses the source map string into a stream of ``SourceMapItem`` items.

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -158,9 +158,13 @@ class SourceMap(BaseModel):
 
     def parse(self) -> Iterator[SourceMapItem]:
         """
-        Parses the source map string into a stream of ``SourceMapItem`` items.
+        Parses the source map string into a stream of
+        :class:`~ethpm_types.contract_type.SourceMapItem` items.
         Useful for when parsing the map according to compiler-specific
         decompilation rules back to the source code language files.
+
+        Returns:
+            Iterator[:class:`~ethpm_types.contract_type.SourceMapItem`]
         """
 
         item = None

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -171,16 +171,16 @@ class SourceMap(BaseModel):
                 expanded_row = row.split(":")
 
                 if item is None:
-                    start = int(extract_sourcemap_item(expanded_row, 0) or "-1")
-                    stop = int(extract_sourcemap_item(expanded_row, 1) or "-1")
-                    contract_id = int(extract_sourcemap_item(expanded_row, 2) or "-1")
+                    start = int(extract_sourcemap_item(expanded_row, 0) or -1)
+                    stop = int(extract_sourcemap_item(expanded_row, 1) or -1)
+                    contract_id = int(extract_sourcemap_item(expanded_row, 2) or -1)
                     jump_code = extract_sourcemap_item(expanded_row, 3) or ""
 
                 else:
-                    start = int(extract_sourcemap_item(expanded_row, 0, item.start or "-1"))
-                    stop = int(extract_sourcemap_item(expanded_row, 1, item.stop or "-1"))
+                    start = int(extract_sourcemap_item(expanded_row, 0, item.start or -1))
+                    stop = int(extract_sourcemap_item(expanded_row, 1, item.stop or -1))
                     contract_id = int(
-                        extract_sourcemap_item(expanded_row, 2, item.contract_id or "-1")
+                        extract_sourcemap_item(expanded_row, 2, item.contract_id or -1)
                     )
                     jump_code = extract_sourcemap_item(expanded_row, 3, item.jump_code or "")
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -174,8 +174,8 @@ class SourceMap(BaseModel):
     def __repr__(self) -> str:
         return self.__root__
 
-    def __str__(self) -> str:
-        return self.__root__
+    # def __str__(self) -> str:
+    #     return self.__root__
 
     def parse(self) -> Iterator[SourceMapItem]:
         """

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ extras_require = {
         "mypy>=0.991",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
-        "flake8>=5.0.4",  # Style linter
+        "flake8>=5.0.4,<6",  # Style linter
         "flake8-breakpoint>=1.1.0",  # detect breakpoints left in code
         "flake8-print>=4.0.0",  # detect print statements left in code
         "isort>=5.10.1",  # Import sorting linter

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ extras_require = {
     ],
     "lint": [
         "black>=22.12.0,<23",  # auto-formatter and linter
-        "mypy>=0.991",  # Static type analyzer
+        "mypy>=0.991,<1",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed
         "flake8>=5.0.4,<6",  # Style linter
         "flake8-breakpoint>=1.1.0",  # detect breakpoints left in code
         "flake8-print>=4.0.0",  # detect print statements left in code
-        "isort>=5.10.1",  # Import sorting linter
+        "isort>=5.10.1,<5.11",  # Import sorting linter
     ],
     "doc": [
         "myst-parser>=0.17.0,<0.18",  # Tools for parsing markdown files in the docs

--- a/tests/test_source_map.py
+++ b/tests/test_source_map.py
@@ -66,6 +66,14 @@ def serialize(sourcemap: Iterator[SourceMapItem]) -> str:
 @pytest.mark.parametrize("sourcemap_filename", SOURCE_MAP_FILES)
 def test_source_map(sourcemap_filename):
     sourcemap = SOURCE_MAP_FILES[sourcemap_filename].read_text().strip()
-    sm = SourceMap.construct(__root__=sourcemap)
+    sourcemap_obj = SourceMap.construct(__root__=sourcemap)
     # Serialize back to the sourcemap to make sure we decoded it properly
-    assert serialize(sm.parse()) == sourcemap
+    assert serialize(sourcemap_obj.parse()) == sourcemap
+
+
+def test_repr_and_str():
+    key = list(SOURCE_MAP_FILES.keys())[0]
+    sourcemap = SOURCE_MAP_FILES[key].read_text().strip()
+    sourcemap_obj = SourceMap(__root__=sourcemap)
+    assert repr(sourcemap_obj) == sourcemap
+    assert str(sourcemap_obj) == sourcemap

--- a/tests/test_source_map.py
+++ b/tests/test_source_map.py
@@ -17,7 +17,7 @@ def serialize(sourcemap: Iterator[SourceMapItem]) -> str:
             continue
 
         skip_start = previous_item and item.start == previous_item.start
-        skip_stop = previous_item and item.stop == previous_item.stop
+        skip_stop = previous_item and item.length == previous_item.length
         skip_contract_id = previous_item and item.contract_id == previous_item.contract_id
         skip_jump_code = previous_item and item.jump_code == previous_item.jump_code
 
@@ -32,7 +32,7 @@ def serialize(sourcemap: Iterator[SourceMapItem]) -> str:
             if not skip_start:
                 result += str(item.start) if item.start is not None else "-1"
             result += ":"
-            result += str(item.stop) if item.stop is not None else "-1"
+            result += str(item.length) if item.length is not None else "-1"
             result += ";"
 
         elif skip_jump_code:
@@ -40,7 +40,7 @@ def serialize(sourcemap: Iterator[SourceMapItem]) -> str:
                 result += str(item.start) if item.start is not None else "-1"
             result += ":"
             if not skip_stop:
-                result += str(item.stop) if item.stop is not None else "-1"
+                result += str(item.length) if item.length is not None else "-1"
             result += ":"
             result += str(item.contract_id) if item.contract_id is not None else "-1"
             result += ";"
@@ -50,7 +50,7 @@ def serialize(sourcemap: Iterator[SourceMapItem]) -> str:
                 result += str(item.start) if item.start is not None else "-1"
             result += ":"
             if not skip_stop:
-                result += str(item.stop) if item.stop is not None else "-1"
+                result += str(item.length) if item.length is not None else "-1"
             result += ":"
             if not skip_contract_id:
                 result += str(item.contract_id) if item.contract_id is not None else "-1"


### PR DESCRIPTION
### What I did and How I Did It

My main goal here is trying to understand, so if you review this PR, please make help me do so!

So I noticed that `__repr__` for `SourceMap` looked funny, so I starting poking in that. I found `SourceMapItem` and the `parse()` method so wanted to know more about how that worked because the docs were sort of missing.

* Adds `__repr__` implementation to `SourceMap`
* Adds `__str__` implementation to `SourceMap`
* Adds docs to `SourceMapItem`
* Renames `stop` to `length` in `SourceMapItem`

fixes: APE-581

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
