### PR TITLE
feat: able to get defining function in AST object [APE-677]

### DIFF
--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -5,6 +5,8 @@ from pydantic import root_validator
 from ethpm_types.base import BaseModel
 from ethpm_types.sourcemap import SourceMapItem
 
+SourceLocation = Tuple[int, int, int, int]
+
 
 class ASTNode(BaseModel):
     ast_type: str
@@ -80,13 +82,17 @@ class ASTNode(BaseModel):
         }
 
     @property
-    def line_numbers(self) -> Tuple[int, int, int, int]:
+    def line_numbers(self) -> SourceLocation:
         """
         The values needed for constructing the line numbers for this node
         in the form ``[lineno, col_offset, end_lineno, end_col_offset]``.
         """
 
         return self.lineno, self.col_offset, self.end_lineno, self.end_col_offset
+
+    @property
+    def functions(self) -> List["ASTNode"]:
+        return [n for n in self.children if n.ast_type == "FunctionDef"]
 
     def get_node(self, src: SourceMapItem) -> Optional["ASTNode"]:
         if self.src.start == src.start and self.src.length == src.length:
@@ -99,7 +105,13 @@ class ASTNode(BaseModel):
 
         return None
 
-    def get_nodes_at_line(self, line_numbers: Tuple[int, int, int, int]) -> List["ASTNode"]:
+    def get_nodes_at_line(self, line_numbers: SourceLocation) -> List["ASTNode"]:
+        """
+        Get the AST nodes for the given line number combination
+        :param line_numbers:
+        :return:
+        """
+
         nodes = []
         if self.line_numbers == line_numbers:
             nodes.append(self)
@@ -109,3 +121,14 @@ class ASTNode(BaseModel):
             nodes.extend(subs)
 
         return nodes
+
+    def get_defining_function(self, line_numbers: SourceLocation) -> Optional["ASTNode"]:
+        """
+        Get the function that defines the given line numbers.
+        """
+
+        for function in self.functions:
+            if function.get_nodes_at_line(line_numbers):
+                return function
+
+        return None

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -92,9 +92,26 @@ class ASTNode(BaseModel):
 
     @property
     def functions(self) -> List["ASTNode"]:
+        """
+        All function nodes defined at this level.
+
+        **NOTE**: This is only populated on a ``Module`` AST node.
+        """
+
         return [n for n in self.children if n.ast_type == "FunctionDef"]
 
     def get_node(self, src: SourceMapItem) -> Optional["ASTNode"]:
+        """
+        Get a node by source.
+
+        Args:
+            src (:class:`~ethpm_types.sourcemap.SourceMapItem`): The source map
+              item to seek in the AST.
+
+        Returns:
+            Optional[``ASTNode``]: The matching node, if found, else ``None``.
+        """
+
         if self.src.start == src.start and self.src.length == src.length:
             return self
 
@@ -108,8 +125,13 @@ class ASTNode(BaseModel):
     def get_nodes_at_line(self, line_numbers: SourceLocation) -> List["ASTNode"]:
         """
         Get the AST nodes for the given line number combination
-        :param line_numbers:
-        :return:
+
+        Args:
+            line_numbers (``SourceLocation``): A tuple in the form of
+              [lineno, col_offset, end_lineno, end_col_offset].
+
+        Returns:
+            List[``ASTNode``]: All matching nodes.
         """
 
         nodes = []
@@ -125,6 +147,14 @@ class ASTNode(BaseModel):
     def get_defining_function(self, line_numbers: SourceLocation) -> Optional["ASTNode"]:
         """
         Get the function that defines the given line numbers.
+
+        Args:
+            line_numbers (``SourceLocation``): A tuple in the form of
+              [lineno, col_offset, end_lineno, end_col_offset].
+
+        Returns:
+            Optional[``ASTNode``]: The function definition AST node if found,
+              else ``None``.
         """
 
         for function in self.functions:

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -142,8 +142,12 @@ def test_ast():
     idx = SourceMapItem.parse_str("104:8:0")
     stmt = node.get_node(idx)
     stmts = node.get_nodes_at_line((6, 14, 6, 26))
+    funcs = node.functions
     assert stmt.ast_type == "Compare"
     assert stmt.line_numbers == (7, 11, 7, 19)
     assert len(stmts) == 2
     assert stmts[0].ast_type == "arguments"
     assert stmts[1].ast_type == "arg"
+    assert len(funcs) == 1
+    assert node.get_defining_function((7, 11, 7, 14)) == funcs[0]
+    assert node.get_defining_function((55, 11, 56, 14)) is None


### PR DESCRIPTION
### What I did

Realized it would be convenient for coverage work to let us look up defining method AST nodes via found statement nodes.

### How I did it

The functions at module level AST are found via `[n for n in self.children if n.ast_type == "FunctionDef"]`
And if any function node contains the given line numbers, than it must be the defining function node.
Else it may not be in a function, and that is fine also.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
