### PR TITLE
feat: allow list for tuple of line numbers [APE-679]

### DIFF
--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -141,7 +141,7 @@ class ASTNode(BaseModel):
                 "`(lineno, col_offset, end_lineno, end_coloffset)`"
             )
 
-        if all([x == y for x, y in zip(self.line_numbers, line_numbers)]):
+        if all(x == y for x, y in zip(self.line_numbers, line_numbers)):
             nodes.append(self)
 
         for child in self.children:

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -135,7 +135,13 @@ class ASTNode(BaseModel):
         """
 
         nodes = []
-        if self.line_numbers == line_numbers:
+        if len(line_numbers) != 4:
+            raise ValueError(
+                "Line numbers should given in form "
+                "`(lineno, col_offset, end_lineno, end_coloffset)`"
+            )
+
+        if all([x == y for x, y in zip(self.line_numbers, line_numbers)]):
             nodes.append(self)
 
         for child in self.children:

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -137,7 +137,7 @@ class ASTNode(BaseModel):
         nodes = []
         if len(line_numbers) != 4:
             raise ValueError(
-                "Line numbers should given in form "
+                "Line numbers should be given in form of "
                 "`(lineno, col_offset, end_lineno, end_coloffset)`"
             )
 

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -150,4 +150,5 @@ def test_ast():
     assert stmts[1].ast_type == "arg"
     assert len(funcs) == 1
     assert node.get_defining_function((7, 11, 7, 14)) == funcs[0]
+    assert node.get_defining_function([7, 11, 7, 14]) == funcs[0]
     assert node.get_defining_function((55, 11, 56, 14)) is None


### PR DESCRIPTION
### What I did

Hack that allows sending lists for to `Tuple[int, int, int, int]`.
Makes some things easier down the line.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
