### PR TITLE
refactor: use our own hexbytes [APE-730]

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -2,7 +2,6 @@ from functools import singledispatchmethod
 from typing import Callable, Dict, Iterable, List, Optional, TypeVar, Union
 
 from eth_utils import add_0x_prefix, is_0x_prefixed
-from hexbytes import HexBytes
 from pydantic import Field, validator
 
 from ethpm_types.abi import (
@@ -17,7 +16,7 @@ from ethpm_types.abi import (
 from ethpm_types.ast import ASTNode
 from ethpm_types.base import BaseModel
 from ethpm_types.sourcemap import PCMap, SourceMap
-from ethpm_types.utils import Hex, is_valid_hex
+from ethpm_types.utils import Hex, HexBytes, is_valid_hex
 
 
 # TODO link references & link values are for solidity, not used with Vyper

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     url="https://github.com/ApeWorX/ethpm-types",
     include_package_data=True,
     install_requires=[
-        "hexbytes>=0.2.3,<1",
+        "hexbytes>=0.3.0,<1",
         "pydantic>=1.10.1,<2",
         "eth-utils>=2.0.0,<3",
         "py-cid>=0.3.0,<0.4",


### PR DESCRIPTION
### What I did

noticed we were not using our own hexbytes class for contract bytescode.
seems like we can? shouldnt be a breaking change since the classes are supposed to be the same, unless it breaks someone `isinstance` check ... hmmmm.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
