### PR TITLE
feat: add a way to "classify" AST nodes [APE-755]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
+-   repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:
     -   id: flake8

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import List, Optional, Tuple, Union
 
 from pydantic import root_validator
@@ -8,10 +9,29 @@ from ethpm_types.sourcemap import SourceMapItem
 SourceLocation = Tuple[int, int, int, int]
 
 
+class ASTClassification(Enum):
+    UNCLASSIFIED = 0
+    """Unclassified AST type (default)."""
+
+    FUNCTION_DEF = 1
+    """ASTTypes related to defining a function."""
+
+    CONTENT = 2
+    """ASTTypes related to the content within a function."""
+
+    COMPILER = 3
+    """ASTTypes related content injected by the compiler."""
+
+
 class ASTNode(BaseModel):
     ast_type: str
     """
-    The type of AST node this is, such as ``FunctionDef``.
+    The compiler-given AST node type this is, such as ``FunctionDef``.
+    """
+
+    classification: ASTClassification = ASTClassification.UNCLASSIFIED
+    """
+    A generic classification of what type of AST this is.
     """
 
     doc_str: Optional[Union[str, "ASTNode"]] = None

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -20,7 +20,7 @@ class ASTClassification(Enum):
 class ASTNode(BaseModel):
     ast_type: str
     """
-    The compiler-given AST node type this is, such as ``FunctionDef``.
+    The compiler-given AST node type, such as ``FunctionDef``.
     """
 
     classification: ASTClassification = ASTClassification.UNCLASSIFIED

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -16,9 +16,6 @@ class ASTClassification(Enum):
     FUNCTION_DEF = 1
     """ASTTypes related to defining a function."""
 
-    CONTENT = 2
-    """ASTTypes related to the content within a function."""
-
     COMPILER = 3
     """ASTTypes related content injected by the compiler."""
 

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -16,9 +16,6 @@ class ASTClassification(Enum):
     FUNCTION_DEF = 1
     """ASTTypes related to defining a function."""
 
-    COMPILER = 3
-    """ASTTypes related content injected by the compiler."""
-
 
 class ASTNode(BaseModel):
     ast_type: str


### PR DESCRIPTION
### What I did

now, compiler APIs in Ape can add classify the ast nodes they create such that downstream services can use those classifications to parse content, such as knowing the nodes in a function def versus the function content (something we have to do for coverage)

### How I did it

* add new model
* add member to ast node
* default to unclassified, so it wont be breaking change

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
