### PR TITLE
feat: allow `dev` field to be set on `PCMapItem`

### DIFF
--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -46,7 +46,6 @@ class BaseModel(_BaseModel):
         *args,
         **kwargs,
     ) -> Any:
-
         if isinstance(v, HexBytes):
             return v.hex()
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "pysha3>=1.0.2,<2.0.0",  # Backend for eth-hash
     ],
     "lint": [
-        "black>=22.12.0,<23",  # auto-formatter and linter
+        "black>=23.3.0,<24",  # auto-formatter and linter
         "mypy>=0.991,<1",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed

--- a/tests/test_pc_map.py
+++ b/tests/test_pc_map.py
@@ -63,9 +63,9 @@ def test_pc_map_getting_and_setting():
     assert 186 in pcmap
 
     # Test __getitem__
-    assert pcmap[186] == [10, 20, 10, 40]
-    assert pcmap["186"] == [10, 20, 10, 40]
+    assert pcmap[186] == {"location": [10, 20, 10, 40]}
+    assert pcmap["186"] == {"location": [10, 20, 10, 40]}
 
     # Test __setitem__
     pcmap[184] = [5, 20, 10, 40]
-    assert pcmap["184"] == [5, 20, 10, 40]
+    assert pcmap["184"] == {"location": [5, 20, 10, 40]}


### PR DESCRIPTION
### What I did

for the benefit of checking compiler-injected messages, allow `dev` to be set on the `PCMapItem` instances

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
