### PR TITLE
feat: add `errors` calculated property on `ContractType` [APE-810]

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -148,7 +148,7 @@ class ABIList(List[T]):
         self,
         iterable: Optional[Iterable[T]] = None,
         *,
-        selector_id_size=32,
+        selector_id_size: int = 32,
         selector_hash_fn: Optional[Callable[[str], bytes]] = None,
     ):
         self._selector_id_size = selector_id_size
@@ -396,7 +396,7 @@ class ContractType(BaseModel):
         Returns:
             :class:`~ethpm_types.contract_type.ABIList`
         """
-        return self._get_abis(filter_fn=lambda a: isinstance(a, ErrorABI))
+        return self._get_abis(selector_id_size=4, filter_fn=lambda a: isinstance(a, ErrorABI))
 
     @property
     def methods(self) -> ABIList:

--- a/tests/data/SolidityContract.json
+++ b/tests/data/SolidityContract.json
@@ -25,6 +25,22 @@
       "type": "event"
     },
     {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "addr",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "counter",
+          "type": "uint256"
+        }
+      ],
+      "name":"FooError",
+      "type":"error"
+    },
+    {
       "inputs": [],
       "name": "getAddressList",
       "outputs": [

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -6,7 +6,7 @@ import pytest
 from eth_utils import keccak
 
 from ethpm_types import ContractType
-from ethpm_types.abi import ABI, EventABI, MethodABI
+from ethpm_types.abi import ABI, ErrorABI, EventABI, MethodABI
 
 CONTRACT_NAMES = ("SolidityContract.json", "VyperContract.json")
 DATA_FILES = {
@@ -15,6 +15,7 @@ DATA_FILES = {
 MUTABLE_METHOD_SELECTOR_BYTES = keccak(text="setNumber(uint256)")
 VIEW_METHOD_SELECTOR_BYTES = keccak(text="getStruct()")
 EVENT_SELECTOR_BYTES = keccak(text="NumberChange(uint256,uint256)")
+ERROR_SELECTOR_BYTES = keccak(text="FooError(address,uint256)")
 
 
 view_selector_parametrization = pytest.mark.parametrize(
@@ -48,6 +49,17 @@ event_selector_parametrization = pytest.mark.parametrize(
         EVENT_SELECTOR_BYTES[:32],
         f"0x{EVENT_SELECTOR_BYTES.hex()}",
         f"0x{EVENT_SELECTOR_BYTES[:32].hex()}",
+    ),
+)
+error_selector_parametrization = pytest.mark.parametrize(
+    "selector",
+    (
+        "FooError",
+        "FooError(address,uint256)",
+        ERROR_SELECTOR_BYTES,
+        ERROR_SELECTOR_BYTES[:32],
+        f"0x{ERROR_SELECTOR_BYTES.hex()}",
+        f"0x{ERROR_SELECTOR_BYTES[:32].hex()}",
     ),
 )
 
@@ -173,6 +185,15 @@ def test_select_and_contains_event_by_name_and_selectors(selector, vyper_contrac
     event = contract_type.events[selector]
     assert isinstance(event, EventABI)
     assert event.name == "NumberChange"
+
+
+@error_selector_parametrization
+def test_elect_and_contains_error_by_name_and_selectors(selector, solidity_contract):
+    contract_type = ContractType.parse_obj(solidity_contract)
+    assert selector in contract_type.errors
+    event = contract_type.errors[selector]
+    assert isinstance(event, ErrorABI)
+    assert event.name == "FooError"
 
 
 def test_select_and_contains_by_abi(vyper_contract):


### PR DESCRIPTION
### What I did

This allows easier integrations with custom exceptions in downstream services, such as Ape.
Now, we can check for selectors to find the correct ABI.

### How I did it

* new abi list for errors
* refactored to save code
* added test

### How to verify it

`contract_type.errors` should contains your custom solidity errors.
"0x123" in contract_type.errors to check for a selector


### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
