### PR TITLE
fix: issue with no-length AST nodes [APE-908]

### DIFF
--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -143,7 +143,7 @@ class ASTNode(BaseModel):
             Optional[``ASTNode``]: The matching node, if found, else ``None``.
         """
 
-        if self.src.start == src.start and self.src.length == src.length:
+        if self.src.start == src.start and (self.src.length or 0) == (src.length or 0):
             return self
 
         for child in self.children:

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ethpm_types import SourceMapItem
 from ethpm_types.ast import ASTNode
 
@@ -95,7 +97,7 @@ AST_JSON = {
                             "end_lineno": 7,
                             "lineno": 7,
                             "node_id": 13,
-                            "src": "111:1:0",
+                            "src": "111:0:0",
                             "value": 5,
                         },
                         "src": "104:8:0",
@@ -152,3 +154,11 @@ def test_ast():
     assert node.get_defining_function((7, 11, 7, 14)) == funcs[0]
     assert node.get_defining_function([7, 11, 7, 14]) == funcs[0]
     assert node.get_defining_function((55, 11, 56, 14)) is None
+
+
+@pytest.mark.parametrize("length", (0, None))
+def test_ast_get_node_no_length(length):
+    node = ASTNode.parse_obj(AST_JSON)
+    idx = SourceMapItem(start=111, length=length, contract_id=None, jump_code="-")
+    actual = node.get_node(idx)
+    assert actual.ast_type == "Int"


### PR DESCRIPTION
### What I did

When comparing ASTs / getting nodes (used in PCMap building in `ape-vyper`), if the length is 0 and the other is None, it really is the same thing .However, the comparison would fail and we would fail to find the source and it would cause all sorts of problems...

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
