### PR TITLE
feat: pc property on statements [APE-956]

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -406,6 +406,16 @@ class Statement(BaseModel):
     """
 
     type: str
+    """
+    The type of statement it is, such as `source` or a virtual identifier.
+    """
+
+    # TODO: Make required in 0.6
+    pc: int = -1
+    """
+    The PC value for the statement.
+    Defaults to -1 for backwards compatibility but should always be present.
+    """
 
     def __repr__(self) -> str:
         return f"<Statement type={self.type}>"

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Tuple, Union
+from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import requests
 from cid import make_cid  # type: ignore
@@ -410,11 +410,9 @@ class Statement(BaseModel):
     The type of statement it is, such as `source` or a virtual identifier.
     """
 
-    # TODO: Make required in 0.6
-    pc: int = -1
+    pcs: Set[int] = set()
     """
     The PC value for the statement.
-    Defaults to -1 for backwards compatibility but should always be present.
     """
 
     def __repr__(self) -> str:


### PR DESCRIPTION
### What I did

For better tracking of statements executed, it is kinda needed to include the pc value, especially when dealing with virtual statements. sorry, this was the way to go, a little forgotten but no biggie

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
