### PR TITLE
feat: utilize AST name [APE-1014]

### DIFF
--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -17,6 +17,11 @@ class ASTClassification(Enum):
 
 
 class ASTNode(BaseModel):
+    name: Optional[str] = None
+    """
+    The node's name if it has one, such as a function name.
+    """
+
     ast_type: str
     """
     The compiler-given AST node type, such as ``FunctionDef``.

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -379,7 +379,7 @@ class Function(Closure):
             ``ethpm_types.source.Content``
         """
 
-        start = max(location[0], self.offset)
+        start = max(location[0], self.content.begin_lineno)
         stop = location[2] + 1
         content = {n: self.content[n] for n in range(start, stop) if n in self.content.line_numbers}
         return Content(__root__=content)
@@ -607,7 +607,8 @@ class ContractSource(BaseModel):
         if not signature_lines or not content_lines:
             return None
 
-        offset = ast.lineno + len(signature_lines)
+        signature_start = ast.lineno
+        offset = signature_start + len(signature_lines)
 
         # Check if method ID points to a calling method.
         name = None
@@ -652,8 +653,9 @@ class ContractSource(BaseModel):
             ):
                 name = full_name.split("(")[0]
 
+        signature_dict = {signature_start + i: ln for i, ln in enumerate(signature_lines)}
         content_dict = {offset + i: ln for i, ln in enumerate(content_lines)}
-        content = Content(__root__=content_dict)
+        content = Content(__root__={**signature_dict, **content_dict})
         Function.update_forward_refs()
 
         return Function(

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -625,8 +625,13 @@ class ContractSource(BaseModel):
             name = method.name
             self._function_ast_cache[method_id.hex()] = ast
 
+        elif ast.name is not None:
+            # Use the AST name.
+            name = ast.name
+
         if name is None:
             # This method is not present in the ABI, maybe because it is internal.
+            # Also, the name is missing from the AST node.
             # Combine the signature lines into a single string.
             name = "".join([x.strip() for x in signature_lines]).rstrip()
 

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -622,13 +622,13 @@ class ContractSource(BaseModel):
                 # Is the same function. It's safe to use the method ABI name.
                 method = self.contract_type.methods[method_id]
                 name = method.name
-                full_name = method.signature
+                full_name = method.selector
 
         elif method_id and method_id in self.contract_type.methods:
             # Not in cache yet. Assume is calling.
             method = self.contract_type.methods[method_id]
             name = method.name
-            full_name = method.signature
+            full_name = method.selector
             self._function_ast_cache[method_id.hex()] = ast
 
         elif ast.name is not None:

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -467,6 +467,7 @@ def test_vy_ast():
     assert stmts[0].ast_type == "arguments"
     assert stmts[1].ast_type == "arg"
     assert len(funcs) == 1
+    assert funcs[0].name == "setNumber"
     assert node.get_defining_function((7, 11, 7, 14)) == funcs[0]
     assert node.get_defining_function([7, 11, 7, 14]) == funcs[0]
     assert node.get_defining_function((55, 11, 56, 14)) is None

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from hexbytes import HexBytes as OriginalHexBytes
+from pydantic import Field
 
 from ethpm_types import BaseModel, HexBytes
 
@@ -9,7 +12,9 @@ TEST_MODEL_DICT = {
     "int_bytes": 0,
     "bool_bytes": False,
     "original_bytes": OriginalHexBytes("0"),
+    "optional_bytes": HexBytes(0),
 }
+EMPTY_BYTES = HexBytes("0x0000000000000000000000000000000000000000000000000000000000000000")
 
 
 class TestModel(BaseModel):
@@ -19,6 +24,13 @@ class TestModel(BaseModel):
     int_bytes: HexBytes
     bool_bytes: HexBytes
     original_bytes: HexBytes
+    optional_bytes: Optional[HexBytes] = None
+
+
+class Block(BaseModel):
+    gas_limit: int = Field(alias="gasLimit")
+    hash: Optional[HexBytes] = None
+    parent_hash: HexBytes = Field(EMPTY_BYTES, alias="parentHash")
 
 
 def test_hexbytes_dict():
@@ -28,7 +40,7 @@ def test_hexbytes_dict():
         assert item.type_ == HexBytes
 
     test_dict = test_model.dict()
-    assert len(test_dict) == 6
+    assert len(test_dict) == 7
 
     for _, v in test_dict.items():
         assert v == "0x00"
@@ -38,12 +50,31 @@ def test_hexbytes_dict_exclude():
     test_model = TestModel.parse_obj(TEST_MODEL_DICT)
 
     test_dict = test_model.dict(exclude={"byte_bytes"})
-    assert len(test_dict) == 5
+    assert len(test_dict) == 6
     assert "byte_bytes" not in test_dict.keys()
 
 
 def test_hexbytes_json():
-    test_model = TestModel.parse_obj(TEST_MODEL_DICT)
-    test_json = test_model.json(exclude={"bool_bytes", "byte_bytes", "int_bytes"})
+    test_models = (TestModel.parse_obj(TEST_MODEL_DICT), TestModel(**TEST_MODEL_DICT))
+    for model in test_models:
+        test_json = model.json(exclude={"bool_bytes", "byte_bytes", "int_bytes"})
+        assert test_json == (
+            '{"bytearray_bytes":"0x00",'
+            '"optional_bytes":"0x00",'
+            '"original_bytes":"0x00",'
+            '"str_bytes":"0x00"}'
+        )
 
-    assert test_json == '{"bytearray_bytes":"0x00","original_bytes":"0x00","str_bytes":"0x00"}'
+
+def test_realistic_model():
+    block = Block(
+        gasLimit=123124,
+        hash=HexBytes("0x1be99d96b0b5784b07aea2750aee16a2efbe46cf271b246835bc101fd94bc992"),
+    )
+    actual = block.json(sort_keys=True)
+    expected = (
+        '{"gasLimit":123124,'
+        '"hash":"0x1be99d96b0b5784b07aea2750aee16a2efbe46cf271b246835bc101fd94bc992",'
+        f'"parentHash":"{EMPTY_BYTES.hex()}"}}'
+    )
+    assert actual == expected

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -133,3 +133,14 @@ def test_contract_source(vyper_contract, source, source_base):
         == "getEmptyTupleOfDynArrayStructs() -> (DynArray[MyStruct, 10], DynArray[MyStruct, 10])"
     )
     assert repr(function) == "<Function getEmptyTupleOfDynArrayStructs>"
+
+
+def test_contract_source_use_method_id(vyper_contract, source, source_base):
+    actual = ContractSource.create(vyper_contract, source, source_base)
+    location = (121, 4, 121, 46)
+    method_id = vyper_contract._selector_hash_fn(
+        vyper_contract.methods["getEmptyTupleOfDynArrayStructs"].selector
+    )
+    function = actual.lookup_function(location, method_id=method_id)
+    assert function.name == "getEmptyTupleOfDynArrayStructs"
+    assert function.full_name == "getEmptyTupleOfDynArrayStructs()"

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -128,4 +128,8 @@ def test_contract_source(vyper_contract, source, source_base):
     function = actual.lookup_function(location)
     # Tests ``Function`` class here.
     assert function.name == "getEmptyTupleOfDynArrayStructs"
+    assert (
+        function.full_name
+        == "getEmptyTupleOfDynArrayStructs() -> (DynArray[MyStruct, 10], DynArray[MyStruct, 10])"
+    )
     assert repr(function) == "<Function getEmptyTupleOfDynArrayStructs>"

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -133,6 +133,8 @@ def test_contract_source(vyper_contract, source, source_base):
         == "getEmptyTupleOfDynArrayStructs() -> (DynArray[MyStruct, 10], DynArray[MyStruct, 10])"
     )
     assert repr(function) == "<Function getEmptyTupleOfDynArrayStructs>"
+    # Ensure signature lines are also in content.
+    assert str(function.content).splitlines()[0].startswith("def getEmptyTupleOfDynArrayStructs()")
 
 
 def test_contract_source_use_method_id(vyper_contract, source, source_base):


### PR DESCRIPTION
### What I did

didn't realize sometimes AST nodes had names, which is useful for function definitions.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
