### PR TITLE
perf: check sources once [APE-1100]

### DIFF
--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -165,10 +165,10 @@ class PackageManifest(BaseModel):
 
     @root_validator
     def check_contract_source_ids(cls, values):
+        sources = values.get("sources", {}) or {}
         contract_types = values.get("contract_types", {}) or {}
         for alias in contract_types:
             source_id = values["contract_types"][alias].source_id
-            sources = values.get("sources", {}) or {}
             if source_id and (source_id not in sources):
                 raise ValueError(f"'{source_id}' missing from `sources`.")
 


### PR DESCRIPTION
### What I did

prevents grabbing sources from dict every  time

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
