### PR TITLE
feat: allow initializing bytecodes using bytes [APE-1131]

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -321,6 +321,13 @@ class ContractType(BaseModel):
 
         return None
 
+    @validator("deployment_bytecode", "runtime_bytecode", pre=True)
+    def validate_bytecode(cls, value):
+        if not isinstance(value, dict):
+            return {"bytecode": value}
+
+        return value
+
     @property
     def constructor(self) -> ConstructorABI:
         """

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -251,3 +251,9 @@ def test_fallback_and_receive_not_defined(contract):
     # Both `VyperContract` and `SolidityContract` do not define these.
     assert contract.receive is None
     assert contract.fallback is None
+
+
+def test_init_using_bytes(contract):
+    raw_bytes = contract.deployment_bytecode.bytecode
+    new_contract = ContractType(abi=[], deploymentBytecode=raw_bytes)
+    assert new_contract.deployment_bytecode.bytecode == raw_bytes


### PR DESCRIPTION
### What I did

allow initializing contract type bytecode values using non-dicts. Sometimes it feels tedious to wrap bytecode in a dict like `{"bytecode": _bytes}`, especially when using Contract Types outside of ape compilers. This makes it a little easier.

### How I did it

A pydantic validator (`pre=True`)

### How to verify it

`ContractContainer(abi=[], deploymentBytecode=HexBytes("0x123")`

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
