### PR TITLE
refactor!: remove unused backrefs [APE-1287]

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -4,9 +4,6 @@ from pydantic import Extra, Field
 
 from .base import BaseModel
 
-if TYPE_CHECKING:
-    from ethpm_types.contract_type import ContractType
-
 
 class ABIType(BaseModel):
     name: Optional[str] = None
@@ -108,12 +105,6 @@ class ConstructorABI(BaseModel):
     type: Literal["constructor"]
     """The value ``"constructor"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
-
     stateMutability: str = "nonpayable"
     """
     Can be either ``"payable"`` or ``"nonpayable"``.
@@ -162,12 +153,6 @@ class FallbackABI(BaseModel):
     type: Literal["fallback"]
     """The value ``"fallback"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
-
     stateMutability: str = "nonpayable"
     """
     Can be either ``"payable"`` or ``"nonpayable"``.
@@ -200,12 +185,6 @@ class ReceiveABI(BaseModel):
     type: Literal["receive"]
     """The value ``"receive"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
-
     stateMutability: Literal["payable"]
     """The value ``"payable"``."""
 
@@ -233,12 +212,6 @@ class MethodABI(BaseModel):
 
     type: Literal["function"]
     """The value ``"function"``."""
-
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
 
     name: str
     """The name of the method."""
@@ -313,12 +286,6 @@ class EventABI(BaseModel):
     type: Literal["event"]
     """The value ``"event"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
-
     name: str
     """The name of the event."""
 
@@ -357,12 +324,6 @@ class ErrorABI(BaseModel):
     type: Literal["error"]
     """The value ``"error"``."""
 
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
-
     name: str
     """The name of the error."""
 
@@ -398,12 +359,6 @@ class StructABI(BaseModel):
 
     type: Literal["struct"]
     """The value ``"struct"``."""
-
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
 
     name: str
     """The name of the struct."""
@@ -443,12 +398,6 @@ class UnprocessedABI(BaseModel):
 
     type: str
     """The type name as a string."""
-
-    contract_type: Optional["ContractType"] = Field(None, exclude=True, repr=False)
-    """
-    A reference to this ABI's contract type. This gets set during ``ContractType``
-    deserialization.
-    """
 
     class Config:
         extra = Extra.allow

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, List, Literal, Optional, Union
+from typing import List, Literal, Optional, Union
 
-from pydantic import Extra, Field
+from pydantic import Extra
 
 from .base import BaseModel
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -338,9 +338,7 @@ class ContractType(BaseModel):
         """
 
         # Use default constructor (no args) when no defined.
-        abi = self._get_first_instance(ConstructorABI) or ConstructorABI(type="constructor")
-        abi.contract_type = self
-        return abi
+        return self._get_first_instance(ConstructorABI) or ConstructorABI(type="constructor")
 
     @property
     def fallback(self) -> Optional[FallbackABI]:
@@ -443,8 +441,6 @@ class ContractType(BaseModel):
 
         filter_fn = filter_fn or noop
         method_abis = [abi for abi in self.abi if filter_fn(abi)]
-        for abi in method_abis:
-            abi.contract_type = self
 
         return ABIList(
             method_abis,
@@ -454,14 +450,8 @@ class ContractType(BaseModel):
 
     def _get_first_instance(self, _type: Type[ABI_SINGLETON_T]) -> Optional[ABI_SINGLETON_T]:
         for abi in self.abi:
-            if not isinstance(abi, _type):
-                continue
-
-            # TODO: Figure out better way than type ignore.
-            #  getting `<nothing> has no attribute contract_type`.
-            #  probably using generics wrong but not sure how else to do it.
-            abi.contract_type = self  # type: ignore[attr-defined]
-            return abi
+            if isinstance(abi, _type):
+                return abi
 
         return None
 

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -193,17 +193,6 @@ def test_contract_type_excluded_in_repr_abi(vyper_contract):
     assert "contract_type" not in actual
 
 
-def test_contract_type_backrefs(oz_contract_type):
-    assert oz_contract_type.events, "setup: Test contract should have events"
-    assert oz_contract_type.view_methods, "setup: Test contract should have view methods"
-    assert oz_contract_type.mutable_methods, "setup: Test contract should have mutable methods"
-
-    assert oz_contract_type.constructor.contract_type == oz_contract_type
-    assert all(e.contract_type == oz_contract_type for e in oz_contract_type.events)
-    assert all(m.contract_type == oz_contract_type for m in oz_contract_type.mutable_methods)
-    assert all(m.contract_type == oz_contract_type for m in oz_contract_type.view_methods)
-
-
 @view_selector_parametrization
 def test_select_view_method_from_all_methods(selector, vyper_contract):
     method_abi = vyper_contract.methods[selector]

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -14,6 +14,10 @@ ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get
 EXAMPLES_RAW_URL = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples"
 
 
+def test_can_generate_schema():
+    PackageManifest.schema()
+
+
 @pytest.mark.parametrize(
     "example_name",
     [f.name for f in ETHPM_SPEC_REPO.get_contents("examples")],  # type: ignore[union-attr]


### PR DESCRIPTION
BREAKING CHANGE

### What I did

When running `PackageManifest.schema()`, an error was being raised about needing to run `update_forward_refs` for `ContractType` against the ABI classes. Realized that we didn't need these within `ethpm_types` at all, also checking for downstream impact

fixes: #83

### How I did it

Removed `contract_type` members from `abi.py` and backref updates in `contract_type.py`

### How to verify it

Tests pass, validate downstream impact

### Checklist

- [ ] Audit downstream usage of this feature
- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
