### PR TITLE
fix: update forward refs [APE-1288]

### DIFF
--- a/ethpm_types/__init__.py
+++ b/ethpm_types/__init__.py
@@ -1,4 +1,14 @@
-from .abi import ABI
+from .abi import (
+    ABI,
+    ConstructorABI,
+    ErrorABI,
+    EventABI,
+    FallbackABI,
+    MethodABI,
+    ReceiveABI,
+    StructABI,
+    UnprocessedABI,
+)
 from .ast import ASTNode
 from .base import BaseModel
 from .contract_type import Bytecode, ContractInstance, ContractType
@@ -6,6 +16,26 @@ from .manifest import PackageManifest, PackageMeta
 from .source import Checksum, Compiler, Source
 from .sourcemap import PCMap, PCMapItem, SourceMap, SourceMapItem
 from .utils import HexBytes
+
+ContractType.update_forward_refs(
+    ConstructorABI=ConstructorABI,
+    ErrorABI=ErrorABI,
+    EventABI=EventABI,
+    FallbackABI=FallbackABI,
+    MethodABI=MethodABI,
+    ReceiveABI=ReceiveABI,
+    StructABI=StructABI,
+    UnprocessedABI=UnprocessedABI,
+)
+
+ConstructorABI.update_forward_refs(ContractType=ContractType)
+ErrorABI.update_forward_refs(ContractType=ContractType)
+EventABI.update_forward_refs(ContractType=ContractType)
+FallbackABI.update_forward_refs(ContractType=ContractType)
+MethodABI.update_forward_refs(ContractType=ContractType)
+ReceiveABI.update_forward_refs(ContractType=ContractType)
+StructABI.update_forward_refs(ContractType=ContractType)
+UnprocessedABI.update_forward_refs(ContractType=ContractType)
 
 __all__ = [
     "ABI",

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -14,6 +14,10 @@ ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get
 EXAMPLES_RAW_URL = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/examples"
 
 
+def test_can_generate_schema():
+    PackageManifest.schema()
+
+
 @pytest.mark.parametrize(
     "example_name",
     [f.name for f in ETHPM_SPEC_REPO.get_contents("examples")],  # type: ignore[union-attr]


### PR DESCRIPTION
### What I did

Made sure that back refs were updating properly

fixes: #83

### How I did it

Thanks to https://stackoverflow.com/questions/63420889/fastapi-pydantic-circular-references-in-separate-files

### How to verify it

New test passes

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
