### PR TITLE
feat: support pydantic v2 [APE-1372]

### DIFF
--- a/ethpm_types/_pydantic_v1.py
+++ b/ethpm_types/_pydantic_v1.py
@@ -1,0 +1,23 @@
+# TODO: Can delete this file once we full migrate to v2.
+try:
+    from pydantic.v1 import AnyUrl as _AnyUrl  # type: ignore
+    from pydantic.v1 import BaseModel as _BaseModel  # type: ignore
+    from pydantic.v1 import (  # type: ignore
+        Extra,
+        Field,
+        FileUrl,
+        ValidationError,
+        root_validator,
+        validator,
+    )
+except ImportError:
+    from pydantic import AnyUrl as _AnyUrl  # type: ignore
+    from pydantic import BaseModel as _BaseModel  # type: ignore
+    from pydantic import (  # type: ignore
+        Extra,
+        Field,
+        FileUrl,
+        ValidationError,
+        root_validator,
+        validator,
+    )

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,6 +1,9 @@
 from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
-from pydantic import Extra, Field
+try:
+    from pydantic.v1 import Extra, Field
+except ImportError:
+    from pydantic import Extra, Field
 
 from .base import BaseModel
 

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,11 +1,7 @@
 from typing import TYPE_CHECKING, List, Literal, Optional, Union
 
-try:
-    from pydantic.v1 import Extra, Field
-except ImportError:
-    from pydantic import Extra, Field
-
-from .base import BaseModel
+from ethpm_types._pydantic_v1 import Extra, Field
+from ethpm_types.base import BaseModel
 
 if TYPE_CHECKING:
     from ethpm_types.contract_type import ContractType

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -1,7 +1,10 @@
 from enum import Enum
 from typing import Dict, Iterator, List, Optional, Union
 
-from pydantic import root_validator
+try:
+    from pydantic.v1 import root_validator
+except ImportError:
+    from pydantic import root_validator
 
 from ethpm_types.base import BaseModel
 from ethpm_types.sourcemap import SourceMapItem

--- a/ethpm_types/ast.py
+++ b/ethpm_types/ast.py
@@ -1,11 +1,7 @@
 from enum import Enum
 from typing import Dict, Iterator, List, Optional, Union
 
-try:
-    from pydantic.v1 import root_validator
-except ImportError:
-    from pydantic import root_validator
-
+from ethpm_types._pydantic_v1 import root_validator
 from ethpm_types.base import BaseModel
 from ethpm_types.sourcemap import SourceMapItem
 from ethpm_types.utils import SourceLocation

--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -1,11 +1,7 @@
 import json
 from typing import Any, Dict, no_type_check
 
-try:
-    from pydantic.v1 import BaseModel as _BaseModel
-except ImportError:
-    from pydantic import BaseModel as _BaseModel
-
+from ethpm_types._pydantic_v1 import _BaseModel
 from ethpm_types.utils import HexBytes
 
 

--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -1,7 +1,10 @@
 import json
 from typing import Any, Dict, no_type_check
 
-from pydantic import BaseModel as _BaseModel
+try:
+    from pydantic.v1 import BaseModel as _BaseModel
+except ImportError:
+    from pydantic import BaseModel as _BaseModel
 
 from ethpm_types.utils import HexBytes
 

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -3,11 +3,7 @@ from typing import Callable, Dict, Iterable, List, Optional, Type, TypeVar, Unio
 
 from eth_utils import add_0x_prefix, is_0x_prefixed
 
-try:
-    from pydantic.v1 import Field, validator
-except ImportError:
-    from pydantic import Field, validator
-
+from ethpm_types._pydantic_v1 import Field, validator
 from ethpm_types.abi import (
     ABI,
     ConstructorABI,

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -2,7 +2,11 @@ from functools import singledispatchmethod
 from typing import Callable, Dict, Iterable, List, Optional, Type, TypeVar, Union
 
 from eth_utils import add_0x_prefix, is_0x_prefixed
-from pydantic import Field, validator
+
+try:
+    from pydantic.v1 import Field, validator
+except ImportError:
+    from pydantic import Field, validator
 
 from ethpm_types.abi import (
     ABI,

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -338,9 +338,9 @@ class ContractType(BaseModel):
         """
 
         # Use default constructor (no args) when no defined.
-        abi = self._get_first_instance(ConstructorABI) or ConstructorABI(type="constructor")
-        abi.contract_type = self
-        return abi
+        return self._get_first_instance(ConstructorABI) or ConstructorABI(
+            type="constructor", contract_type=self
+        )
 
     @property
     def fallback(self) -> Optional[FallbackABI]:

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -1,6 +1,9 @@
 from typing import Dict, List, Optional
 
-from pydantic import Field, root_validator, validator
+try:
+    from pydantic.v1 import Field, root_validator, validator
+except ImportError:
+    from pydantic import Field, root_validator, validator
 
 from .base import BaseModel
 from .contract_type import BIP122_URI, ContractInstance, ContractType

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -1,14 +1,10 @@
 from typing import Dict, List, Optional
 
-try:
-    from pydantic.v1 import Field, root_validator, validator
-except ImportError:
-    from pydantic import Field, root_validator, validator
-
-from .base import BaseModel
-from .contract_type import BIP122_URI, ContractInstance, ContractType
-from .source import Compiler, Source
-from .utils import Algorithm, AnyUrl
+from ethpm_types._pydantic_v1 import Field, root_validator, validator
+from ethpm_types.base import BaseModel
+from ethpm_types.contract_type import BIP122_URI, ContractInstance, ContractType
+from ethpm_types.source import Compiler, Source
+from ethpm_types.utils import Algorithm, AnyUrl
 
 ALPHABET = set("abcdefghijklmnopqrstuvwxyz")
 NUMBERS = set("0123456789")

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -381,7 +381,9 @@ class Function(Closure):
 
         start = max(location[0], self.content.begin_lineno)
         stop = location[2] + 1
-        content = {n: self.content[n] for n in range(start, stop) if n in self.content.line_numbers}
+        content = {
+            n: str(self.content[n]) for n in range(start, stop) if n in self.content.line_numbers
+        }
         return Content(__root__=content)
 
     def get_content_asts(self, location: SourceLocation) -> List[ASTNode]:

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -3,7 +3,11 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import requests
 from cid import make_cid  # type: ignore
-from pydantic import root_validator, validator
+
+try:
+    from pydantic.v1 import root_validator, validator
+except ImportError:
+    from pydantic import root_validator, validator
 
 from ethpm_types.ast import ASTClassification, ASTNode, SourceLocation
 from ethpm_types.base import BaseModel

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -4,11 +4,7 @@ from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 import requests
 from cid import make_cid  # type: ignore
 
-try:
-    from pydantic.v1 import root_validator, validator
-except ImportError:
-    from pydantic import root_validator, validator
-
+from ethpm_types._pydantic_v1 import root_validator, validator
 from ethpm_types.ast import ASTClassification, ASTNode, SourceLocation
 from ethpm_types.base import BaseModel
 from ethpm_types.contract_type import ContractType

--- a/ethpm_types/sourcemap.py
+++ b/ethpm_types/sourcemap.py
@@ -1,6 +1,9 @@
 from typing import Dict, Iterator, List, Optional, Union
 
-from pydantic import root_validator
+try:
+    from pydantic.v1 import root_validator
+except ImportError:
+    from pydantic import root_validator
 
 from ethpm_types.base import BaseModel
 from ethpm_types.utils import SourceLocation

--- a/ethpm_types/sourcemap.py
+++ b/ethpm_types/sourcemap.py
@@ -1,10 +1,6 @@
 from typing import Dict, Iterator, List, Optional, Union
 
-try:
-    from pydantic.v1 import root_validator
-except ImportError:
-    from pydantic import root_validator
-
+from ethpm_types._pydantic_v1 import root_validator
 from ethpm_types.base import BaseModel
 from ethpm_types.utils import SourceLocation
 

--- a/ethpm_types/sourcemap.py
+++ b/ethpm_types/sourcemap.py
@@ -189,16 +189,17 @@ class PCMap(BaseModel):
 
         for key, value in self.__root__.items():
             location = value["location"]
+            dev = str(value["dev"]) if "dev" in value and value["dev"] is not None else None
             if location is not None:
                 result = PCMapItem(
                     line_start=int(location[0]) if location[0] is not None else None,
                     column_start=int(location[1]) if location[1] is not None else None,
                     line_end=int(location[2]) if location[2] is not None else None,
                     column_end=int(location[3]) if location[3] is not None else None,
-                    dev=str(value.get("dev", "")),
+                    dev=dev,
                 )
             else:
-                result = PCMapItem(dev=str(value.get("dev", "")))
+                result = PCMapItem(dev=dev)
 
             results[int(key)] = result
 

--- a/ethpm_types/sourcemap.py
+++ b/ethpm_types/sourcemap.py
@@ -188,16 +188,17 @@ class PCMap(BaseModel):
         results = {}
 
         for key, value in self.__root__.items():
-            if value["location"] is not None:
+            location = value["location"]
+            if location is not None:
                 result = PCMapItem(
-                    line_start=value["location"][0],
-                    column_start=value["location"][1],
-                    line_end=value["location"][2],
-                    column_end=value["location"][3],
-                    dev=value.get("dev"),
+                    line_start=int(location[0]) if location[0] is not None else None,
+                    column_start=int(location[1]) if location[1] is not None else None,
+                    line_end=int(location[2]) if location[2] is not None else None,
+                    column_end=int(location[3]) if location[3] is not None else None,
+                    dev=str(value.get("dev", "")),
                 )
             else:
-                result = PCMapItem(dev=value.get("dev"))
+                result = PCMapItem(dev=str(value.get("dev", "")))
 
             results[int(key)] = result
 

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -4,12 +4,7 @@ from typing import Tuple, Union
 
 from hexbytes import HexBytes as BaseHexBytes
 
-try:
-    from pydantic.v1 import AnyUrl as _AnyUrl
-    from pydantic.v1 import FileUrl
-except ImportError:
-    from pydantic import AnyUrl as _AnyUrl
-    from pydantic import FileUrl
+from ethpm_types._pydantic_v1 import FileUrl, _AnyUrl
 
 CONTENT_ADDRESSED_SCHEMES = {"ipfs"}
 AnyUrl = Union[_AnyUrl, FileUrl]

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -3,8 +3,13 @@ from hashlib import md5, sha3_256, sha256
 from typing import Tuple, Union
 
 from hexbytes import HexBytes as BaseHexBytes
-from pydantic import AnyUrl as _AnyUrl
-from pydantic import FileUrl
+
+try:
+    from pydantic.v1 import AnyUrl as _AnyUrl
+    from pydantic.v1 import FileUrl
+except ImportError:
+    from pydantic import AnyUrl as _AnyUrl
+    from pydantic import FileUrl
 
 CONTENT_ADDRESSED_SCHEMES = {"ipfs"}
 AnyUrl = Union[_AnyUrl, FileUrl]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,5 @@ multi_line_output = 3
 use_parentheses = true
 
 [tool.mypy]
-exclude = "build"
+exclude = ["build", "ethpm_types/_pydantic_v1.py"]
 plugins = ["pydantic.mypy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,5 @@ multi_line_output = 3
 use_parentheses = true
 
 [tool.mypy]
-exclude = ["build", "ethpm_types/_pydantic_v1.py"]
+exclude = ["build"]
 plugins = ["pydantic.mypy"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,3 +5,4 @@ exclude =
 	.eggs
 	docs
 	build
+	_pydantic_v1.py

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "hexbytes>=0.3.0,<1",
-        "pydantic>=1.10.7,<3",
+        "pydantic>=1.10.7,!=2.0.*,!=2.1.*,!=2.2.*,<3",
         "eth-utils>=2.1.0,<3",
         "py-cid>=0.3.0,<0.4",
         "requests>=2.29.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "hexbytes>=0.3.0,<1",
-        "pydantic>=1.10.7,<2",
+        "pydantic>=1.10.7",  # pydantic >=2 is supported
         "eth-utils>=2.1.0,<3",
         "py-cid>=0.3.0,<0.4",
         "requests>=2.29.0,<3",

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "hexbytes>=0.3.0,<1",
-        "pydantic>=1.10.7",  # pydantic >=2 is supported
+        "pydantic>=1.10.7,<3",
         "eth-utils>=2.1.0,<3",
         "py-cid>=0.3.0,<0.4",
         "requests>=2.29.0,<3",

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -2,12 +2,8 @@ from typing import Dict, List, Optional
 
 from hexbytes import HexBytes as OriginalHexBytes
 
-try:
-    from pydantic.v1 import Field
-except ImportError:
-    from pydantic import Field
-
 from ethpm_types import BaseModel, HexBytes
+from ethpm_types._pydantic_v1 import Field
 
 TEST_MODEL_DICT = {
     "byte_bytes": b"\x00",

--- a/tests/test_hexbytes.py
+++ b/tests/test_hexbytes.py
@@ -1,7 +1,11 @@
 from typing import Dict, List, Optional
 
 from hexbytes import HexBytes as OriginalHexBytes
-from pydantic import Field
+
+try:
+    from pydantic.v1 import Field
+except ImportError:
+    from pydantic import Field
 
 from ethpm_types import BaseModel, HexBytes
 

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -3,7 +3,11 @@ import os
 import github
 import pytest
 import requests
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
 
 from ethpm_types import PackageManifest
 

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -4,12 +4,8 @@ import github
 import pytest
 import requests
 
-try:
-    from pydantic.v1 import ValidationError
-except ImportError:
-    from pydantic import ValidationError
-
-from ethpm_types import PackageManifest
+from ethpm_types._pydantic_v1 import ValidationError
+from ethpm_types.manifest import PackageManifest
 
 ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get_repo(
     "ethpm/ethpm-spec"

--- a/tests/test_schema_fuzzing.py
+++ b/tests/test_schema_fuzzing.py
@@ -2,7 +2,12 @@ import pytest
 import requests
 from hypothesis import HealthCheck, given, settings
 from hypothesis_jsonschema import from_schema
-from pydantic import ValidationError
+
+try:
+    from pydantic.v1 import ValidationError
+except ImportError:
+    from pydantic import ValidationError
+
 
 from ethpm_types import PackageManifest
 

--- a/tests/test_schema_fuzzing.py
+++ b/tests/test_schema_fuzzing.py
@@ -3,13 +3,8 @@ import requests
 from hypothesis import HealthCheck, given, settings
 from hypothesis_jsonschema import from_schema
 
-try:
-    from pydantic.v1 import ValidationError
-except ImportError:
-    from pydantic import ValidationError
-
-
 from ethpm_types import PackageManifest
+from ethpm_types._pydantic_v1 import ValidationError
 
 ETHPM_SCHEMA = "https://raw.githubusercontent.com/ethpm/ethpm-spec/master/spec/v3.spec.json"
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,5 +1,10 @@
 import pytest
-from pydantic import FileUrl
+
+try:
+    from pydantic.v1 import FileUrl
+except ImportError:
+    from pydantic import FileUrl
+
 
 from ethpm_types.source import Content, ContractSource, Source
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,11 +1,6 @@
 import pytest
 
-try:
-    from pydantic.v1 import FileUrl
-except ImportError:
-    from pydantic import FileUrl
-
-
+from ethpm_types._pydantic_v1 import FileUrl
 from ethpm_types.source import Content, ContractSource, Source
 
 SOURCE_LOCATION = (


### PR DESCRIPTION
### What I did

support pydantic 2 in a backwards-compatible way.

### How I did it

try to import from `pydantic.v1` (works in v2) and fall back to `pydantic` (works in v1)

relax the dependency so it matches both v1 and v2.

this is a quick solution that allows us to keep compat with other packages that are starting to update to pydantic v2 already.

the full migration will require a more involved refactor.

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
