### PR TITLE
fix: issue where could not access contract types with same name as attribute [APE-1379]

### DIFF
--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -191,7 +191,7 @@ class PackageManifest(BaseModel):
             return self.__getattribute__(attr_name)
         except AttributeError:
             # Check if contract type name.
-            contract_type = self.get_contract_Type(attr_name)
+            contract_type = self.get_contract_type(attr_name)
             if contract_type:
                 return contract_type
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,3 +88,14 @@ def vyper_default_contract(get_contract_type):
 def fallback_contract(request, get_contract_type):
     key = "VyDefault" if request.param == "Vyper" else "SolFallbackAndReceive"
     return get_contract_type(key)
+
+
+@pytest.fixture
+def package_manifest(solidity_contract, vyper_contract):
+    return PackageManifest(
+        contractTypes={
+            solidity_contract.name: solidity_contract,
+            vyper_contract.name: vyper_contract,
+        },
+        sources={solidity_contract.source_id: "", vyper_contract.source_id: ""},
+    )

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -73,3 +73,15 @@ def test_file_bases_dependency_url():
         buildDependencies={"test-package": "file:///path/to/manifest/test-package.json"}
     )
     assert manifest.dependencies["test-package"] == "file:///path/to/manifest/test-package.json"
+
+
+def test_getattr(package_manifest, solidity_contract):
+    actual = package_manifest.SolidityContract
+    expected = solidity_contract
+    assert actual == expected
+
+
+def test_get_contract_type(package_manifest, solidity_contract):
+    actual = package_manifest.get_contract_type("SolidityContract")
+    expected = solidity_contract
+    assert actual == expected


### PR DESCRIPTION
### What I did

since `__getattr__` was the only way to access a contract type nicely, it would causes issues when trying use one named `.meta`. Also fixes a strange thing that sometimes happens with attributes. Adds a couple tests

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
