### PR TITLE
fix: package name couldn't contain all valid characters [APE-1408]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
     -   id: check-yaml
 
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 23.9.1
     hooks:
       - id: black
         name: black

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -41,7 +41,7 @@ class PackageName(str):
 
     @classmethod
     def check_valid_characters(cls, value):
-        assert set(value) < ALPHABET.union(NUMBERS).union(
+        assert set(value) <= ALPHABET.union(NUMBERS).union(
             "-"
         ), "Characters in name must be one of a-z or 0-9 or '-'"
         return value

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ exclude =
 	docs
 	build
 	_pydantic_v1.py
+	ethpm_types/version.py

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ extras_require = {
         "pysha3>=1.0.2,<2.0.0",  # Backend for eth-hash
     ],
     "lint": [
-        "black>=23.7.0,<24",  # auto-formatter and linter
+        "black>=23.9.1,<24",  # auto-formatter and linter
         "mypy>=1.5.1,<2",  # Static type analyzer
         "types-setuptools",  # Needed due to mypy typeshed
         "types-requests",  # Needed due to mypy typeshed

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 
 from ethpm_types._pydantic_v1 import ValidationError
-from ethpm_types.manifest import PackageManifest
+from ethpm_types.manifest import ALPHABET, NUMBERS, PackageManifest
 from ethpm_types.source import Content, Source
 
 ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get_repo(
@@ -106,3 +106,14 @@ def test_unpack_sources():
         assert baz_expected.is_file()
         assert foo_expected.read_text() == str(foo_txt)
         assert baz_expected.read_text() == str(baz_txt)
+
+
+def test_package_name_using_all_valid_characters():
+    """
+    Tests against a bug where we were unable to create a
+    package manifest who's name contained all the valid
+    characters.
+    """
+    name = "a" + "".join(list(ALPHABET.union(NUMBERS).union({"-"})))
+    manifest = PackageManifest(name=name, version="0.1.0")
+    assert manifest.name == name


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #89 
Fixes: APE-1408

### How I did it

< => <=

### How to verify it

make a package manifest with a project name containing every valid letter and number at least once.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
