### PR TITLE
fix: handle empty dict bytecodes [APE-1452]

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -323,9 +323,13 @@ class ContractType(BaseModel):
 
     @validator("deployment_bytecode", "runtime_bytecode", pre=True)
     def validate_bytecode(cls, value):
-        if isinstance(value, dict):
+        if not value:
+            return {}
+
+        elif isinstance(value, dict):
             rest_attributes = value
             code = value["bytecode"]
+
         else:
             rest_attributes = {}
             code = value

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -254,7 +254,12 @@ def test_fallback_and_receive_not_defined(contract):
     assert contract.fallback is None
 
 
-def test_init_using_bytes(contract):
+def test_init_bytecode_using_bytes(contract):
     raw_bytes = HexBytes(contract.deployment_bytecode.bytecode)
     new_contract = ContractType(abi=[], deploymentBytecode=raw_bytes)
     assert new_contract.deployment_bytecode.bytecode == raw_bytes.hex()
+
+
+def test_init_bytecode_using_empty_dict(contract):
+    new_contract = ContractType(abi=[], deploymentBytecode={})
+    assert new_contract.deployment_bytecode.bytecode is None


### PR DESCRIPTION
### What I did

The latest merge to main in Ape core failed because of this bug!
So we need this patch released and then im going to pin to the next version in core.

### How I did it

handle empty dicts

### How to verify it

core tests pass again

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
