### PR TITLE
feat: PackageManifest utilities for working with Compilers list [APE-1497]

### DIFF
--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -291,9 +291,6 @@ class PackageManifest(BaseModel):
               compilers.
         """
 
-        full_list: List[Compiler] = self.compilers or []
-        for compiler in compilers:
-            if compiler not in full_list:
-                full_list.append(compiler)
-
-        self.compilers = full_list
+        start = self.compilers or []
+        start.extend([c for c in compilers if c not in start])
+        self.compilers = start

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -280,7 +280,7 @@ class PackageManifest(BaseModel):
 
         return None
 
-    def update_compilers(self, compilers: List[Compiler]):
+    def add_compilers(self, *compilers: List[Compiler]):
         """
         Update compilers in the manifest. This method appends any
         given compiler with a a different name, version, and settings
@@ -291,9 +291,9 @@ class PackageManifest(BaseModel):
               compilers.
         """
 
-        updated_compilers = [*compilers]
-        for prior_compiler in self.compilers or []:
-            if prior_compiler not in updated_compilers:
-                updated_compilers.append(prior_compiler)
+        if self.compilers is None:
+            self.compilers = []
 
-        self.compilers = updated_compilers
+        for compiler in compilers:
+            if compiler not in self.compilers:
+                self.compilers.append(compiler)

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -282,13 +282,13 @@ class PackageManifest(BaseModel):
 
     def update_compilers(self, compilers: List[Compiler]):
         """
-        Update compilers in the manifest. Any compiler that has
-        different name, version, and settings combination will
-        be appended to this manifest's compilers list.
+        Update compilers in the manifest. This method appends any
+        given compiler with a a different name, version, and settings
+        combination.
 
         Args:
             compilers (List[`~ethpm_types.source.Compiler]`): A list of
-              compilers to add.
+              compilers.
         """
 
         updated_compilers = [*compilers]

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -281,6 +281,16 @@ class PackageManifest(BaseModel):
         return None
 
     def update_compilers(self, compilers: List[Compiler]):
+        """
+        Update compilers in the manifest. Any compiler that has
+        different name, version, and settings combination will
+        be appended to this manifest's compilers list.
+
+        Args:
+            compilers (List[`~ethpm_types.source.Compiler]`): A list of
+              compilers to add.
+        """
+
         updated_compilers = [*compilers]
         for prior_compiler in self.compilers or []:
             if prior_compiler not in updated_compilers:

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -280,7 +280,7 @@ class PackageManifest(BaseModel):
 
         return None
 
-    def add_compilers(self, *compilers: List[Compiler]):
+    def add_compilers(self, *compilers: Compiler):
         """
         Update compilers in the manifest. This method appends any
         given compiler with a a different name, version, and settings
@@ -291,9 +291,9 @@ class PackageManifest(BaseModel):
               compilers.
         """
 
-        if self.compilers is None:
-            self.compilers = []
-
+        full_list: List[Compiler] = self.compilers or []
         for compiler in compilers:
-            if compiler not in self.compilers:
-                self.compilers.append(compiler)
+            if compiler not in full_list:
+                full_list.append(compiler)
+
+        self.compilers = full_list

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -263,3 +263,27 @@ class PackageManifest(BaseModel):
             source_path.parent.mkdir(parents=True, exist_ok=True)
 
             source_path.write_text(content)
+
+    def get_contract_compiler(self, contract_type_name: str) -> Optional[Compiler]:
+        """
+        Get the compiler used to compile the contract type, if it exists.
+
+        Args:
+            contract_type_name (str): The name of the compiled contract.
+
+        Returns:
+            Optional[`~ethpm_types.source.Compiler`]
+        """
+        for compiler in self.compilers or []:
+            if contract_type_name in (compiler.contractTypes or []):
+                return compiler
+
+        return None
+
+    def update_compilers(self, compilers: List[Compiler]):
+        updated_compilers = [*compilers]
+        for prior_compiler in self.compilers or []:
+            if prior_compiler not in updated_compilers:
+                updated_compilers.append(prior_compiler)
+
+        self.compilers = updated_compilers

--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -176,7 +176,7 @@ class PackageManifest(BaseModel):
 
     @validator("contract_types")
     def add_name_to_contract_types(cls, values):
-        aliases = list(values.keys())
+        aliases = list((values or {}).keys())
         # NOTE: Must manually inject names to types here
         for alias in aliases:
             if not values[alias]:

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -44,6 +44,20 @@ class Compiler(BaseModel):
     that used this compiler to generate its outputs.
     """
 
+    def __eq__(self, other) -> bool:
+        if (
+            not hasattr(other, "name")
+            and not hasattr(other, "version")
+            and not hasattr(other, "settings")
+        ):
+            return NotImplemented
+
+        return (
+            self.name == other.name
+            and self.version == other.version
+            and self.settings == other.settings
+        )
+
 
 class Checksum(BaseModel):
     """Checksum information about the contents of a source file."""
@@ -58,6 +72,15 @@ class Checksum(BaseModel):
     """
     The hash of a source files contents generated with the corresponding algorithm.
     """
+
+    @classmethod
+    def from_file(cls, file: Union[Path, str], algorithm: Algorithm = Algorithm.MD5) -> "Checksum":
+        source_path = file if isinstance(file, Path) else Path(file)
+        return cls.from_bytes(source_path.read_bytes(), algorithm=algorithm)
+
+    @classmethod
+    def from_bytes(cls, data: bytes, algorithm: Algorithm = Algorithm.MD5) -> "Checksum":
+        return cls(algorithm=algorithm, hash=compute_checksum(data, algorithm=algorithm))
 
 
 class Content(BaseModel):

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -133,7 +133,7 @@ def test_get_contract_compiler():
     assert manifest.get_contract_compiler("yoyoyo") is None
 
 
-def test_update_compilers():
+def test_add_compilers():
     compiler = Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar"])
     manifest = PackageManifest(
         compilers=[compiler],
@@ -146,7 +146,7 @@ def test_update_compilers():
         Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar", "testtest"]),
         Compiler(name="vyper", version="0.3.10", settings={}, contractTypes=["yoyo"]),
     ]
-    manifest.update_compilers(new_compilers)
+    manifest.update_compilers(*new_compilers)
     assert len(manifest.compilers) == 2
 
 

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -146,10 +146,24 @@ def test_update_compilers():
     assert len(manifest.compilers) == 2
 
 
-def test_none_contract_types():
+def test_contract_types():
     """
     Tests against a bug where validators would fail because
     they tried iterating None.
     """
     manifest = PackageManifest(contractTypes=None)
     assert manifest.contract_types is None
+
+    # Even though snakeCase is the documented way,
+    # Ape tools had been using snake_case in some instances,
+    # so we must continue ensuring both work.
+    manifest = PackageManifest(contract_types=None)
+    assert manifest.contract_types is None
+
+    contract_types = {
+        "foobar": ContractType(contractName="foobar", abi=[]),
+        "testtest": ContractType(contractName="testtest", abi=[]),
+    }
+
+    manifest = PackageManifest(contractTypes=contract_types)
+    assert manifest.contract_types == contract_types

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -146,7 +146,7 @@ def test_add_compilers():
         Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar", "testtest"]),
         Compiler(name="vyper", version="0.3.10", settings={}, contractTypes=["yoyo"]),
     ]
-    manifest.update_compilers(*new_compilers)
+    manifest.add_compilers(*new_compilers)
     assert len(manifest.compilers) == 2
 
 

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -158,12 +158,6 @@ def test_contract_types():
     manifest = PackageManifest(contractTypes=None)
     assert manifest.contract_types is None
 
-    # Even though snakeCase is the documented way,
-    # Ape tools had been using snake_case in some instances,
-    # so we must continue ensuring both work.
-    manifest = PackageManifest(contract_types=None)
-    assert manifest.contract_types is None
-
     contract_types = {
         "foobar": ContractType(contractName="foobar", abi=[]),
         "testtest": ContractType(contractName="testtest", abi=[]),

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -84,6 +84,10 @@ def test_getattr(package_manifest, solidity_contract):
     expected = solidity_contract
     assert actual == expected
 
+    # Show when not an attribute or contract type.
+    with pytest.raises(AttributeError):
+        _ = package_manifest.contractTypes
+
 
 def test_get_contract_type(package_manifest, solidity_contract):
     actual = package_manifest.get_contract_type("SolidityContract")

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -6,9 +6,10 @@ import github
 import pytest
 import requests
 
+from ethpm_types import ContractType
 from ethpm_types._pydantic_v1 import ValidationError
 from ethpm_types.manifest import ALPHABET, NUMBERS, PackageManifest
-from ethpm_types.source import Content, Source
+from ethpm_types.source import Compiler, Content, Source
 
 ETHPM_SPEC_REPO = github.Github(os.environ.get("GITHUB_ACCESS_TOKEN", None)).get_repo(
     "ethpm/ethpm-spec"
@@ -117,3 +118,29 @@ def test_package_name_using_all_valid_characters():
     name = "a" + "".join(list(ALPHABET.union(NUMBERS).union({"-"})))
     manifest = PackageManifest(name=name, version="0.1.0")
     assert manifest.name == name
+
+
+def test_get_contract_compiler():
+    compiler = Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar"])
+    manifest = PackageManifest(
+        compilers=[compiler], contractTypes={"foobar": ContractType(contractNam="foobar")}
+    )
+    assert manifest.get_contract_compiler("foobar") == compiler
+    assert manifest.get_contract_compiler("yoyoyo") is None
+
+
+def test_update_compilers():
+    compiler = Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar"])
+    manifest = PackageManifest(
+        compilers=[compiler],
+        contractTypes={
+            "foobar": ContractType(contractName="foobar", abi=[]),
+            "testtest": ContractType(contractName="testtest", abi=[]),
+        },
+    )
+    new_compilers = [
+        Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar", "testtest"]),
+        Compiler(name="vyper", version="0.3.10", settings={}, contractTypes=["yoyo"]),
+    ]
+    manifest.update_compilers(new_compilers)
+    assert len(manifest.compilers) == 2

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -144,3 +144,12 @@ def test_update_compilers():
     ]
     manifest.update_compilers(new_compilers)
     assert len(manifest.compilers) == 2
+
+
+def test_none_contract_types():
+    """
+    Tests against a bug where validators would fail because
+    they tried iterating None.
+    """
+    manifest = PackageManifest(contractTypes=None)
+    assert manifest.contract_types is None

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -163,5 +163,5 @@ def test_contract_types():
         "testtest": ContractType(contractName="testtest", abi=[]),
     }
 
-    manifest = PackageManifest(contractTypes=contrac
+    manifest = PackageManifest(contractTypes=contract_types)
     assert manifest.contract_types == contract_types

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -163,5 +163,5 @@ def test_contract_types():
         "testtest": ContractType(contractName="testtest", abi=[]),
     }
 
-    manifest = PackageManifest(contractTypes=contract_types)
+    manifest = PackageManifest(contractTypes=contrac
     assert manifest.contract_types == contract_types

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,7 +1,11 @@
+import tempfile
+from pathlib import Path
+
 import pytest
 
 from ethpm_types._pydantic_v1 import FileUrl
-from ethpm_types.source import Content, ContractSource, Source
+from ethpm_types.source import Checksum, Compiler, Content, ContractSource, Source
+from ethpm_types.utils import Algorithm, compute_checksum
 
 SOURCE_LOCATION = (
     "https://github.com/OpenZeppelin/openzeppelin-contracts"
@@ -146,3 +150,36 @@ def test_contract_source_use_method_id(vyper_contract, source, source_base):
     function = actual.lookup_function(location, method_id=method_id)
     assert function.name == "getEmptyTupleOfDynArrayStructs"
     assert function.full_name == "getEmptyTupleOfDynArrayStructs()"
+
+
+def test_compiler_equality():
+    compiler_1 = Compiler(
+        name="yo", version="0.1.0", settings={"foo": "bar"}, contractType=["test1"]
+    )
+    compiler_2 = Compiler(
+        name="yo", version="0.1.0", settings={"foo": "bar"}, contractType=["test1", "test2"]
+    )
+    assert compiler_1 == compiler_2
+
+    compiler_1.name = "yo2"
+    assert compiler_1 != compiler_2
+    compiler_1.name = compiler_2.name
+
+    compiler_1.version = "0.100000.0"
+    assert compiler_1 != compiler_2
+    compiler_1.version = compiler_2.version
+
+    compiler_1.settings["test"] = "123"
+    assert compiler_1 != compiler_2
+    compiler_1.settings = compiler_2.settings
+
+
+def test_checksum_from_file():
+    file = Path(tempfile.mktemp())
+    file.write_text("foobartest123")
+    actual = Checksum.from_file(file)
+    expected = Checksum(
+        algorithm=Algorithm.MD5,
+        hash=compute_checksum(file.read_bytes()),
+    )
+    assert actual == expected


### PR DESCRIPTION
### What I did

* Adds method for getting a contract type's Compiler
* Adds method for updating a manifest's compilers list
* Adds equality override in Compiler for ignoring contractTypes in equality check.
* Fixes bug where we could not have None contract types even though it said we could

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
