### PR TITLE
feat: more `Content` validation

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -108,12 +108,20 @@ class Content(BaseModel):
 
     @root_validator(pre=True)
     def validate_dict(cls, value):
-        data = value["__root__"] if "__root__" in value else value
+        # Handle when full value is empty.
+        value = value or {}
+
+        # Find "root"
+        while "__root__" in value:
+            # Prevent contains-check from failing when None.
+            value = value.pop("__root__") or {}
+
+        # Convert str-content to dict of linenos -> line content
         return {
             "__root__": (
-                {i + 1: x for i, x in enumerate(data.splitlines())}
-                if isinstance(data, str)
-                else data
+                {i + 1: x for i, x in enumerate(value.splitlines())}
+                if isinstance(value, str)
+                else value
             )
         }
 

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -116,6 +116,10 @@ class Content(BaseModel):
             # Prevent contains-check from failing when None.
             value = value.pop("__root__") or {}
 
+            # Convert paths to their texts (str)
+            if isinstance(value, Path):
+                value = {"__root__": value.read_text()}
+
         # Convert str-content to dict of linenos -> line content
         return {
             "__root__": (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,22 @@ SOURCE_ID = "VyperContract.vy"
 
 
 @pytest.fixture
-def get_contract_type():
+def get_contract_type(get_source_path):
     def fn(name: str) -> ContractType:
-        return ContractType.parse_file(COMPILED_BASE / f"{name}.json")
+        path = get_source_path(name, base=COMPILED_BASE)
+        return ContractType.parse_file(path)
+
+    return fn
+
+
+@pytest.fixture
+def get_source_path():
+    def fn(name: str, base: Path = SOURCE_BASE) -> Path:
+        for path in base.iterdir():
+            if path.stem == name:
+                return path
+
+        raise AssertionError("test setup failed - path not found")
 
     return fn
 
@@ -40,8 +53,8 @@ def oz_contract_type(oz_package):
 
 
 @pytest.fixture
-def content_raw() -> str:
-    return (SOURCE_BASE / "VyperContract.vy").read_text()
+def content_raw(get_source_path) -> str:
+    return get_source_path("VyperContract").read_text()
 
 
 @pytest.fixture
@@ -91,11 +104,16 @@ def fallback_contract(request, get_contract_type):
 
 
 @pytest.fixture
-def package_manifest(solidity_contract, vyper_contract):
+def package_manifest(solidity_contract, vyper_contract, get_source_path):
     return PackageManifest(
         contractTypes={
             solidity_contract.name: solidity_contract,
             vyper_contract.name: vyper_contract,
         },
-        sources={solidity_contract.source_id: "", vyper_contract.source_id: ""},
+        sources={
+            solidity_contract.source_id: {
+                "content": get_source_path("SolidityContract"),
+            },
+            vyper_contract.source_id: {"content": get_source_path("VyperContract")},
+        },
     )

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -76,6 +76,11 @@ def test_schema():
     assert expected.issubset(definitions)
 
 
+def test_validate(contract):
+    contract.validate(contract)
+    contract.validate(contract.dict())
+
+
 def test_structs(contract):
     method_abi = _select_abi(contract, "getStruct")
     assert contract.structs == []

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import github
 import pytest
 import requests
+from pydantic import BaseModel
 
 from ethpm_types import ContractType
 from ethpm_types._pydantic_v1 import ValidationError
@@ -229,3 +230,16 @@ def test_validate_fields(package_manifest):
         value_from_model = raw_data.get(name)
         value, errors = field.validate(value_from_model, {}, loc=("response",))
         assert not errors, ", ".join(errors)
+
+
+def test_validate_package_manifest_when_is_field(package_manifest):
+    """
+    Mimics a FastAPI internal behavior.
+    """
+
+    class Response(BaseModel):
+        manifest: PackageManifest  # type: ignore
+
+    response = Response(manifest=package_manifest.dict())
+    assert response.manifest == package_manifest
+    response.__fields__["manifest"].validate(package_manifest.dict(), {}, loc=("response",))

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -217,3 +217,15 @@ def test_contract_types():
 
     manifest = PackageManifest(contractTypes=contract_types)
     assert manifest.contract_types == contract_types
+
+
+def test_validate_fields(package_manifest):
+    """
+    Mimics a FastAPI internal behavior.
+    """
+
+    raw_data = package_manifest.dict()
+    for name, field in package_manifest.__fields__.items():
+        value_from_model = raw_data.get(name)
+        value, errors = field.validate(value_from_model, {}, loc=("response",))
+        assert not errors, ", ".join(errors)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -121,6 +121,54 @@ def test_content_chunk(content_raw):
     assert len(content) == 3
 
 
+def test_content_from_str():
+    lines = ("I am content", " I am line 2 of content")
+    content_str = "\n".join(lines)
+    content = Content.parse_obj(content_str)
+    assert content[1] == lines[0]  # Line 1
+    assert content[2] == lines[1]  # Line 2
+
+    # Assert it passes re-validation.
+    content.validate(content)
+
+
+def test_content_from_root_str():
+    lines = ("I am content", " I am line 2 of content")
+    content_str = "\n".join(lines)
+    content = Content.parse_obj({"__root__": content_str})
+    assert content[1] == lines[0]  # Line 1
+    assert content[2] == lines[1]  # Line 2
+
+    # Assert it passes re-validation.
+    content.validate(content)
+
+
+def test_content_from_dict():
+    lines = {1: "I am content", 2: "I am line 2 of content"}
+    content = Content.parse_obj(lines)
+    assert content[1] == lines[1]  # Line 1
+    assert content[2] == lines[2]  # Line 2
+
+    # Assert it passes re-validation.
+    content.validate(content)
+
+
+def test_content_from_root_dict():
+    lines = {1: "I am content", 2: "I am line 2 of content"}
+    content = Content.parse_obj({"__root__": lines})
+    assert content[1] == lines[1]  # Line 1
+    assert content[2] == lines[2]  # Line 2
+
+    # Assert it passes re-validation.
+    content.validate(content)
+
+
+@pytest.mark.parametrize("val", ("", {}, None))
+def test_content_validate_empty(val):
+    content = Content.parse_obj(val)
+    assert content.validate(val) == Content(__root__={})
+
+
 def test_contract_source(vyper_contract, source, source_base):
     actual = ContractSource.create(vyper_contract, source, source_base)
     assert actual.contract_type == vyper_contract

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -64,6 +64,18 @@ def test_source_repr(source):
     assert repr(source) == f"<Source {checksum.hash}>"
 
 
+def test_source_validate(source):
+    src = source  # alias for avoiding pdb name conflict
+    src_dict = src.dict()
+    assert isinstance(src_dict["content"], str)
+    assert source.validate(src)
+    assert source.validate(src_dict)
+
+    # Change src to a dict and retry
+    src_dict["content"] = {i + 1: ln for i, ln in enumerate(src_dict["content"])}
+    assert source.validate(src_dict)
+
+
 def test_source_line_access(source, content_raw):
     lines = content_raw.splitlines()
     assert source[0] == lines[0]
@@ -73,13 +85,13 @@ def test_source_line_access(source, content_raw):
     assert source[3:5] == lines[3:5]
 
 
-def test_enumerate(source):
+def test_source_enumerate(source):
     for line_idx, line in enumerate(source):
         assert isinstance(line_idx, int)
         assert isinstance(line, str)
 
 
-def test_len(source, content_raw):
+def test_source_len(source, content_raw):
     assert len(source) == len(content_raw.splitlines())
 
 

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -175,6 +175,32 @@ def test_content_from_root_dict():
     content.validate(content)
 
 
+def test_content_from_path():
+    lines = ("I am content", " I am line 2 of content")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = Path(temp_dir) / "Contract.vy"
+        path.write_text("\n".join(lines))
+        content = Content.parse_obj(path)
+        assert content[1] == lines[0]  # Line 1
+        assert content[2] == lines[1]  # Line 2
+
+        # Assert it passes re-validation.
+        content.validate(content)
+
+
+def test_content_from_root_path():
+    lines = ("I am content", " I am line 2 of content")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = Path(temp_dir) / "Contract.vy"
+        path.write_text("\n".join(lines))
+        content = Content.parse_obj({"__root__": path})
+        assert content[1] == lines[0]  # Line 1
+        assert content[2] == lines[1]  # Line 2
+
+        # Assert it passes re-validation.
+        content.validate(content)
+
+
 @pytest.mark.parametrize("val", ("", {}, None))
 def test_content_validate_empty(val):
     content = Content.parse_obj(val)


### PR DESCRIPTION
### What I did

while attempting to fix FastAPI stuff, I made content validate better in some edge cases (weird __root__ models, None types, and direct-Paths)

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
