### PR TITLE
feat: method to help get compiler by name and version

### DIFF
--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -297,6 +297,23 @@ class PackageManifest(BaseModel):
 
             source_path.write_text(content)
 
+    def get_compiler(self, name: str, version: str) -> Optional[Compiler]:
+        """
+        Get a compiler by name and version.
+
+        Args:
+            name (str): The name of the compiler, such as ``"vyper"``.
+            version (str): The version of the compiler.
+
+        Returns:
+            Optional[`~ethpm_types.source.Compiler`]
+        """
+        for compiler in self.compilers:
+            if compiler.name == name.lower() and compiler.version == version:
+                return compiler
+
+        return None
+
     def get_contract_compiler(self, contract_type_name: str) -> Optional[Compiler]:
         """
         Get the compiler used to compile the contract type, if it exists.

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -190,6 +190,15 @@ def test_package_name_using_all_valid_characters():
     assert manifest.name == name
 
 
+def test_get_compiler():
+    compiler = Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar"])
+    manifest = PackageManifest(
+        compilers=[compiler], contractTypes={"foobar": ContractType(contractNam="foobar")}
+    )
+    actual = manifest.get_compiler("vyper", "0.3.7")
+    assert actual == compiler
+
+
 def test_get_contract_compiler():
     compiler = Compiler(name="vyper", version="0.3.7", settings={}, contractTypes=["foobar"])
     manifest = PackageManifest(


### PR DESCRIPTION
### What I did

`manifest.get_compiler(name, version)`

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
