### PR TITLE
fix: compilers with different settings were not disinguished

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -51,6 +51,10 @@ class Compiler(BaseModel):
         return self.__hash__() == other.__hash__()
 
     def _get_settings_str(self) -> str:
+        return self._stringify_settings(self.settings)
+
+    @classmethod
+    def _stringify_settings(cls, settings: Dict) -> str:
         # For hashing and ID.
         # Recursively sort dictionaries based on values
         def sort_value(value: Any) -> Any:
@@ -67,7 +71,7 @@ class Compiler(BaseModel):
                 for k, v in sorted(_dict.items(), key=lambda item: sort_value(item[1]))
             }
 
-        settings: Dict = sort_dict(self.settings or {})
+        settings = sort_dict(settings or {})
         return json.dumps(settings, separators=(",", ":"), sort_keys=True)
 
     def __hash__(self) -> int:

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -70,7 +70,6 @@ def stringify_dict_for_hash(
         str
     """
 
-    # NOTE: Exclude outputSelection as it may contain contract type names.
     if include:
         data = {k: v for k, v in data.items() if k in include}
     if exclude:

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,6 +1,7 @@
+import json
 from enum import Enum
 from hashlib import md5, sha3_256, sha256
-from typing import Tuple
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 from eth_pydantic_types import HexStr
 
@@ -52,6 +53,41 @@ def compute_checksum(content: bytes, algorithm: Algorithm = Algorithm.MD5) -> He
     # TODO: Explore other algorithms needed
     else:
         raise ValueError(f"Unsupported algorithm '{algorithm}'.")
+
+
+def stringify_dict_for_hash(
+    data: Dict, include: Optional[Sequence[str]] = None, exclude: Optional[Sequence[str]] = None
+) -> str:
+    """
+    Convert the given dict to a consistent str that can be used in hash.
+
+    Args:
+        data (Dict): The data to stringify.
+        include (Optional[Sequence[str]]): Optionally filter keys to include.
+        exclude (Optional[Sequence[str]]): Optionally filter keys to exclude.
+
+    Returns:
+        str
+    """
+
+    # NOTE: Exclude outputSelection as it may contain contract type names.
+    if include:
+        data = {k: v for k, v in data.items() if k in include}
+    if exclude:
+        data = {k: v for k, v in data.items() if k not in exclude}
+
+    # For hashing and ID.
+    # Recursively sort dictionaries based on values
+    def _sort(value: Any) -> Any:
+        if isinstance(value, dict):
+            return {k: _sort(value[k]) for k in sorted(value)}
+        elif isinstance(value, list):
+            return [_sort(item) for item in value]
+
+        return value
+
+    sorted_settings = _sort(data or {})
+    return json.dumps(sorted_settings, separators=(",", ":"), sort_keys=True)
 
 
 SourceLocation = Tuple[int, int, int, int]

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -229,10 +229,13 @@ def test_contract_source_use_method_id(vyper_contract, source, source_base):
 
 def test_compiler_equality():
     compiler_1 = Compiler(
-        name="yo", version="0.1.0", settings={"foo": "bar"}, contractType=["test1"]
+        name="yo", version="0.1.0", settings={"evmVersion": "shanghai"}, contractType=["test1"]
     )
     compiler_2 = Compiler(
-        name="yo", version="0.1.0", settings={"foo": "bar"}, contractType=["test1", "test2"]
+        name="yo",
+        version="0.1.0",
+        settings={"evmVersion": "shanghai"},
+        contractType=["test1", "test2"],
     )
     assert compiler_1 == compiler_2
 
@@ -247,26 +250,32 @@ def test_compiler_equality():
     compiler_1.version = compiler_2.version
 
     # Settings affect equality.
-    compiler_2.settings["test"] = "123"
+    compiler_2.settings["evmVersion"] = "london"
     assert compiler_1 != compiler_2
-    del compiler_2.settings["test"]
+    compiler_2.settings["evmVersion"] = "shanghai"
 
 
 def test_compiler_hash():
     compiler_1 = Compiler(
-        name="yo", version="0.2.0", settings={"foo": "bar"}, contractType=["test1"]
+        name="yo", version="0.2.0", settings={"evmVersion": "shanghai"}, contractType=["test1"]
     )
     compiler_2 = Compiler(
         name="foo",
         version="0.1.0",
-        settings={"foo": "bar", "outputSelection": {"test1": ["*"]}},
+        settings={"evmVersion": "shanghai", "outputSelection": {"test1": ["*"]}},
         contractType=["test1", "test2"],
     )
     compiler_3 = Compiler(
-        name="yo", version="0.2.0", settings={"foo": "bar"}, contractType=["test1", "test2"]
+        name="yo",
+        version="0.2.0",
+        settings={"evmVersion": "shanghai"},
+        contractType=["test1", "test2"],
     )
     compiler_4 = Compiler(
-        name="yo", version="0.2.0", settings={"foo": "bar", "test": "123"}, contractType=["test1"]
+        name="yo",
+        version="0.2.0",
+        settings={"evmVersion": "shanghai", "optimizer": {"enabled": False, "runs": 200}},
+        contractType=["test1"],
     )
     compiler_set = {compiler_1, compiler_2, compiler_3, compiler_4}
     assert len(compiler_set) == 3

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -236,17 +236,20 @@ def test_compiler_equality():
     )
     assert compiler_1 == compiler_2
 
+    # Name affects equality.
     compiler_1.name = "yo2"
     assert compiler_1 != compiler_2
     compiler_1.name = compiler_2.name
 
+    # Version affects equality.
     compiler_1.version = "0.100000.0"
     assert compiler_1 != compiler_2
     compiler_1.version = compiler_2.version
 
-    compiler_1.settings["test"] = "123"
+    # Settings affect equality.
+    compiler_2.settings["test"] = "123"
     assert compiler_1 != compiler_2
-    compiler_1.settings = compiler_2.settings
+    del compiler_2.settings["test"]
 
 
 def test_compiler_hash():
@@ -259,11 +262,15 @@ def test_compiler_hash():
     compiler_3 = Compiler(
         name="yo", version="0.2.0", settings={"foo": "bar"}, contractType=["test1"]
     )
-    a_set = {compiler_1, compiler_2, compiler_3}
-    assert len(a_set) == 2
-    assert compiler_1 in a_set
-    assert compiler_2 in a_set
-    assert compiler_3 in a_set
+    compiler_4 = Compiler(
+        name="yo", version="0.2.0", settings={"foo": "bar", "test": "123"}, contractType=["test1"]
+    )
+    compiler_set = {compiler_1, compiler_2, compiler_3, compiler_4}
+    assert len(compiler_set) == 3
+    assert compiler_1 in compiler_set
+    assert compiler_2 in compiler_set
+    assert compiler_3 in compiler_set
+    assert compiler_4 in compiler_set
 
 
 def test_checksum_from_file():

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -257,10 +257,13 @@ def test_compiler_hash():
         name="yo", version="0.2.0", settings={"foo": "bar"}, contractType=["test1"]
     )
     compiler_2 = Compiler(
-        name="foo", version="0.1.0", settings={"foo": "bar"}, contractType=["test1", "test2"]
+        name="foo",
+        version="0.1.0",
+        settings={"foo": "bar", "outputSelection": {"test1": ["*"]}},
+        contractType=["test1", "test2"],
     )
     compiler_3 = Compiler(
-        name="yo", version="0.2.0", settings={"foo": "bar"}, contractType=["test1"]
+        name="yo", version="0.2.0", settings={"foo": "bar"}, contractType=["test1", "test2"]
     )
     compiler_4 = Compiler(
         name="yo", version="0.2.0", settings={"foo": "bar", "test": "123"}, contractType=["test1"]


### PR DESCRIPTION
### What I did

`__eq__` and `__hash__` in `Compiler` did not account for settings.
This is actually really important in `ape-vyper` right now, as it groups input selections based on optimization pragmas.

### How I did it

first stringify  settings dict in a sorted consistent way _without_ `outputSelection` in it. Now, only compiler settings like evmVersion or optimization settings affect the str.

then place that str in the hash

### How to verify it

when using `ape-vyper` 's 0.7 PR you can compile a contract with opimization pragma and it gets own Compiler entry separate from the others using the same version..

See test updates on this PR for a simpler example lol.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
