### PR TITLE
fix: remove pysha3 from test dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ extras_require = {
         # Test-only deps
         "PyGithub>=1.54,<2.0",  # Necessary to pull official schema from github
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
-        "pysha3>=1.0.2,<2.0.0",  # Backend for eth-hash
     ],
     "lint": [
         "black>=23.11.0,<24",  # Auto-formatter and linter


### PR DESCRIPTION
### What I did

Removed pysha3 from test dependencies.  Package is long deprecated and was causing a blocking compilation error on my local.  Does not appear to be used anywhere and appears to have no impact.

### How I did it

Deleted a line

### How to verify it

Install and run tests

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
