### PR TITLE
feat: adds identifier_definitions and identifier_lookup props to ContractType

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -344,6 +344,7 @@ class ContractType(BaseModel):
         return {sig: atype for atype, sig in self._abi_identifiers if sig is not None}
 
     @computed_field(alias="methodIdentifiers")  # type: ignore
+    @cached_property
     def method_identifiers(self) -> Dict[str, str]:
         return {
             atype.selector: sig for atype, sig in self._abi_identifiers if atype.type == "function"

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -331,7 +331,6 @@ class ContractType(BaseModel):
         contract
         """
 
-        # ABITypeWithSelector = Union[ConstructorABI, MethodABI, EventABI, ErrorABI, StructABI]
         def get_id(aitem: ABI) -> str:
             if isinstance(aitem, MethodABI) or isinstance(aitem, ErrorABI):
                 return HexBytes(self._selector_hash_fn(aitem.selector)[:4]).hex()

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -325,7 +325,7 @@ class ContractType(BaseModel):
         return None
 
     @cached_property
-    def identifier_definitions(self) -> Dict[str, str]:
+    def selector_identifiers(self) -> Dict[str, str]:
         """
         Returns a mapping of the full suite of signatures to selectors/topics/IDs for this
         contract.
@@ -347,7 +347,7 @@ class ContractType(BaseModel):
         Returns a mapping of the full suite of selectors/topics/IDs of this contract to human
         readable signature
         """
-        return {v: k for k, v in self.identifier_definitions.items() if v is not None}
+        return {v: k for k, v in self.selector_identifiers.items() if v is not None}
 
     @computed_field(alias="methodIdentifiers")  # type: ignore
     @cached_property

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -328,7 +328,7 @@ class ContractType(BaseModel):
     def identifier_definitions(self) -> Dict[str, str]:
         """
         Returns a mapping of the full suite of signatures to selectors/topics/IDs for this
-        contract
+        contract.
         """
 
         def get_id(aitem: ABI) -> str:

--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -7,7 +7,6 @@ from pydantic import Field, computed_field, field_validator
 
 from ethpm_types.abi import (
     ABI,
-    ABIType,
     ConstructorABI,
     ErrorABI,
     EventABI,
@@ -346,7 +345,9 @@ class ContractType(BaseModel):
 
     @computed_field(alias="methodIdentifiers")  # type: ignore
     def method_identifiers(self) -> Dict[str, str]:
-        return {atype.selector: sig for atype, sig in self._abi_identifiers if atype.type == "function"}
+        return {
+            atype.selector: sig for atype, sig in self._abi_identifiers if atype.type == "function"
+        }
 
     @field_validator("deployment_bytecode", "runtime_bytecode", mode="before")
     @classmethod

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -327,3 +327,25 @@ def test_method_ids_are_set(vyper_contract):
         "mixedArray(uint256,uint256,uint256,uint256)": "0xae8ef2cb",
     }
     assert actual == expected
+
+
+def test_identifier_definitions(vyper_contract):
+    assert len(vyper_contract.identifier_definitions.keys()) == 46
+    assert vyper_contract.identifier_definitions["balances(address)"] == "0x27e235e3"
+    assert vyper_contract.identifier_definitions["owner()"] == "0x8da5cb5b"
+    assert (
+        vyper_contract.identifier_definitions["FooHappened(uint256)"]
+        == "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd"
+    )
+
+
+def test_identifier_lookup(vyper_contract):
+    assert len(vyper_contract.identifier_lookup.keys()) == 46
+    assert vyper_contract.identifier_lookup["0x27e235e3"] == "balances(address)"
+    assert vyper_contract.identifier_lookup["0x8da5cb5b"] == "owner()"
+    assert (
+        vyper_contract.identifier_lookup[
+            "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd"
+        ]
+        == "FooHappened(uint256)"
+    )

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -341,11 +341,11 @@ def test_selector_identifiers(vyper_contract):
 
 def test_identifier_lookup(vyper_contract):
     assert len(vyper_contract.identifier_lookup.keys()) == 46
-    assert vyper_contract.identifier_lookup["0x27e235e3"] == "balances(address)"
-    assert vyper_contract.identifier_lookup["0x8da5cb5b"] == "owner()"
+    assert vyper_contract.identifier_lookup["0x27e235e3"].selector == "balances(address)"
+    assert vyper_contract.identifier_lookup["0x8da5cb5b"].selector == "owner()"
     assert (
         vyper_contract.identifier_lookup[
             "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd"
-        ]
+        ].selector
         == "FooHappened(uint256)"
     )

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -329,12 +329,12 @@ def test_method_ids_are_set(vyper_contract):
     assert actual == expected
 
 
-def test_identifier_definitions(vyper_contract):
-    assert len(vyper_contract.identifier_definitions.keys()) == 46
-    assert vyper_contract.identifier_definitions["balances(address)"] == "0x27e235e3"
-    assert vyper_contract.identifier_definitions["owner()"] == "0x8da5cb5b"
+def test_selector_identifiers(vyper_contract):
+    assert len(vyper_contract.selector_identifiers.keys()) == 46
+    assert vyper_contract.selector_identifiers["balances(address)"] == "0x27e235e3"
+    assert vyper_contract.selector_identifiers["owner()"] == "0x8da5cb5b"
     assert (
-        vyper_contract.identifier_definitions["FooHappened(uint256)"]
+        vyper_contract.selector_identifiers["FooHappened(uint256)"]
         == "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd"
     )
 


### PR DESCRIPTION
### What I did

Added props to ContractType for easy selector <-> signature mapping.  Useful for looking up what a selector might be, or if a selector/topic is part of a known contract.  Might follow this up with a command/plugin for tabular display output.

Or at least I knew them as selector/signature, but terminology seems to be different in this source.  I went looking for official defs and they're all over the place as well.  Even the [Solidity ABI spec](https://docs.soliditylang.org/en/develop/abi-spec.html#events) interchanges Method ID and selector.  I did my best to stick within the convention but my naming is probably off.

I often find myself in a situation where I have an event topic or function or error selector that I'm curious if its a member of one of the contracts in my project.  So it would be nice to have a method for easy lookup that doesn't require me to compute them manually every time.

### How I did it

See code

### How to verify it

Tests do

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
