### PR TITLE
fix: issue with content trailing empty lines

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -121,9 +121,20 @@ class Content(RootModel[Dict[int, str]]):
             data = value.read_text()
         else:
             data = value["root"] if "_root" in value else value
-        return (
-            {i + 1: x for i, x in enumerate(data.splitlines())} if isinstance(data, str) else data
-        )
+
+        if isinstance(data, str):
+            return {i + 1: x for i, x in enumerate(data.rstrip().splitlines())}
+
+        else:
+            last_idx = len(data) - 1
+            for key, val in reversed(data.items()):
+                if val.strip():
+                    break
+
+                last_idx -= 1
+
+            keys = list(data.keys())
+            return {keys[i]: data[keys[i]] for i in range(last_idx + 1)}
 
     def encode(self, *args, **kwargs) -> bytes:
         return str(self).encode(*args, **kwargs)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -129,8 +129,8 @@ def test_content_chunk(content_raw):
     data = {7: chunk[0], 8: chunk[1], 9: chunk[2]}
     content = Content.model_validate(data)
     assert content.begin_lineno == 7
-    assert content.end_lineno == 9
-    assert len(content) == 3
+    assert content.end_lineno == 8
+    assert len(content) == 2
 
 
 def test_content_from_str():
@@ -294,3 +294,9 @@ def test_checksum_from_file():
         hash=compute_checksum(file.read_bytes()),
     )
     assert actual == expected
+
+
+def test_source_excludes_extra_lines():
+    content = "helloworld\n\n\n  \n\n\t\n\n"
+    source = Source(content=content)
+    assert len(source) == 1


### PR DESCRIPTION
### What I did

Some people have been complaining about things compiling over and over again...
Well turns out there was bug where the hashes in Ape always registered changes because it is agreed upon to ignore added whitespace at ends of files but that was not happening.

### How I did it

Ignore empty lines in `Source`

### How to verify it

* Make a Vyper file in Ape
* Add newlines at the end (more than 1)
* Notice it compiles indefinitely

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
