### PR TITLE
fix: handle when key name is optimize instead of optimizer in set

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -60,7 +60,7 @@ class Compiler(BaseModel):
     @classmethod
     def _stringify_settings(cls, settings: Dict) -> str:
         # NOTE: Exclude outputSelection as it may contain contract type names.
-        fields = ("evmVersion", "optimizer")
+        fields = ("evmVersion", "optimizer", "optimize")
         return stringify_dict_for_hash(settings, include=fields)
 
     def __hash__(self) -> int:

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -277,12 +277,19 @@ def test_compiler_hash():
         settings={"evmVersion": "shanghai", "optimizer": {"enabled": False, "runs": 200}},
         contractType=["test1"],
     )
-    compiler_set = {compiler_1, compiler_2, compiler_3, compiler_4}
+    compiler_5 = Compiler(
+        name="yo",
+        version="0.2.0",
+        settings={"evmVersion": "shanghai", "optimize": True},
+        contractType=["test1"],
+    )
+    compiler_set = {compiler_1, compiler_2, compiler_3, compiler_4, compiler_5}
     assert len(compiler_set) == 3
     assert compiler_1 in compiler_set
     assert compiler_2 in compiler_set
     assert compiler_3 in compiler_set
     assert compiler_4 in compiler_set
+    assert compiler_5 in compiler_set
 
 
 def test_checksum_from_file():

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -284,7 +284,7 @@ def test_compiler_hash():
         contractType=["test1"],
     )
     compiler_set = {compiler_1, compiler_2, compiler_3, compiler_4, compiler_5}
-    assert len(compiler_set) == 3
+    assert len(compiler_set) == 4
     assert compiler_1 in compiler_set
     assert compiler_2 in compiler_set
     assert compiler_3 in compiler_set


### PR DESCRIPTION
### What I did

vyper uses the key of `"optmize"` and solidity uses "optimizer" so need to handle both.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
