### PR TITLE
fix: bug where could not set `references` Source model

### DIFF
--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -221,18 +221,21 @@ class Source(BaseModel):
 
     @model_validator(mode="before")
     def validate_model(cls, model):
-        str_model = None
+        content = None
+        other_props = {}
         if isinstance(model, str):
-            str_model = model
+            content = model
 
         elif isinstance(model, dict) and isinstance(model.get("content"), str):
-            str_model = model["content"]
+            content = model["content"]
+            other_props = {k: v for k, v in model.items() if k != "content"}
 
-        return (
-            {"content": Content(root={i + 1: x for i, x in enumerate(str_model.splitlines())})}
-            if str_model
+        content_result = (
+            {"content": Content(root={i + 1: x for i, x in enumerate(content.splitlines())})}
+            if content
             else model
         )
+        return {**content_result, **other_props}
 
     def __repr__(self) -> str:
         repr_id = "Source"

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -307,3 +307,12 @@ def test_source_excludes_extra_lines():
     content = "helloworld\n\n\n  \n\n\t\n\n"
     source = Source(content=content)
     assert len(source) == 1
+
+
+def test_references():
+    """
+    Tests against a bug where the model validation
+    would accidentally ignore all extra properties.
+    """
+    source = Source(content="foo\n", references=["bar.txt"])
+    assert source.references == ["bar.txt"]


### PR DESCRIPTION
### What I did

Critical bugfix... causing compilation problems in Ape.
Basically, we were ignoring all non-content props in the Source model.

### How I did it

stop ignoring and start using.

### How to verify it

you can now set references on Source (see test)

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
