### PR TITLE
test: show that `get_deployment_bytecode` and alike function

### DIFF
--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -349,3 +349,25 @@ def test_identifier_lookup(vyper_contract):
         ].selector
         == "FooHappened(uint256)"
     )
+
+
+def test_get_runtime_bytecode(vyper_contract):
+    actual = vyper_contract.get_runtime_bytecode()
+    assert actual.hex().startswith("0x")
+
+
+def test_get_runtime_bytecode_no_code(vyper_contract):
+    vyper_contract.runtime_bytecode = None
+    actual = vyper_contract.get_runtime_bytecode()
+    assert actual is None
+
+
+def test_get_deployment_bytecode(vyper_contract):
+    actual = vyper_contract.get_deployment_bytecode()
+    assert actual.hex().startswith("0x")
+
+
+def test_get_deployment_bytecode_no_code(vyper_contract):
+    vyper_contract.deployment_bytecode = None
+    actual = vyper_contract.get_deployment_bytecode()
+    assert actual is None


### PR DESCRIPTION
### What I did

Just making sure these methods work, step 1 in research to fixing this https://github.com/ApeWorX/ape/issues/1811

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
