### PR TITLE
feat: easily allow getting all ABIs by name

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -97,7 +97,20 @@ class BaseABI(BaseModel):
     ...
 
 
-class ConstructorABI(BaseABI):
+class HashableABI(BaseABI):
+    @property
+    def selector(self) -> str:
+        """
+        String representing the constructor selector.
+        """
+
+        raise NotImplementedError("Overridden")
+
+    def __hash__(self):
+        return hash(self.selector)
+
+
+class ConstructorABI(HashableABI):
     """
     An ABI describing a contract constructor.
     **NOTE**: The constructor ABI does not have a ``name`` property.
@@ -206,7 +219,7 @@ class ReceiveABI(BaseABI):
         return "receive()"
 
 
-class MethodABI(BaseABI):
+class MethodABI(HashableABI):
     """
     An ABI representing a method you can invoke from a contact.
     """
@@ -279,7 +292,7 @@ class MethodABI(BaseABI):
         return f"{self.name}({input_args}){output_args}"
 
 
-class EventABI(BaseABI):
+class EventABI(HashableABI):
     """
     An ABI describing an event-type defined in a contract.
     """
@@ -317,7 +330,7 @@ class EventABI(BaseABI):
         return f"{self.name}({input_args})"
 
 
-class ErrorABI(BaseABI):
+class ErrorABI(HashableABI):
     """
     An ABI describing an error-type defined in a contract.
     """
@@ -353,7 +366,7 @@ class ErrorABI(BaseABI):
         return f"{self.name}({input_args})"
 
 
-class StructABI(BaseABI):
+class StructABI(HashableABI):
     """
     An ABI describing a struct-type defined in a contract.
     """

--- a/tests/test_contract_type.py
+++ b/tests/test_contract_type.py
@@ -84,6 +84,8 @@ def test_validate(contract):
 def test_structs(contract):
     method_abi = _select_abi(contract, "getStruct")
     assert contract.structs == []
+    # ABIList is treated as dict or a list.
+    assert contract.structs == {}
     assert len(method_abi.outputs) == 1
     output = method_abi.outputs[0]
     assert output.type == "tuple"
@@ -371,3 +373,13 @@ def test_get_deployment_bytecode_no_code(vyper_contract):
     vyper_contract.deployment_bytecode = None
     actual = vyper_contract.get_deployment_bytecode()
     assert actual is None
+
+
+def test_view_methods_dict(vyper_contract):
+    """
+    Showing the best way to select an ABI by name.
+    """
+    actual = dict(vyper_contract.view_methods)
+    abis = actual["getStruct"]
+    assert isinstance(abis, list)
+    assert len(abis) > 0


### PR DESCRIPTION
### What I did

allow you to do:

```python
abi_map =dict(vyper_contract.view_methods)
abi_ls = abi_map["myMethod"]
```

thus affording simpler code in Ape:

```python
contract.myMethod
```

does not have to work so hard.

(Note: am trying to resolve remaining bullet here: https://github.com/ApeWorX/ape/issues/519)

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
