### PR TITLE
fix: issue with empty file sources

### DIFF
--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -9,12 +9,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
           with:
               fetch-depth: 0
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,10 +13,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 
@@ -29,7 +29,7 @@ jobs:
           run: python build_docs.py
 
         - name: Upload HTML artifact
-          uses: actions/upload-artifact@v1
+          uses: actions/upload-artifact@v4
           with:
               name: DocumentationHTML
               path: docs/_build/ethpm-types

--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -12,10 +12,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,10 +17,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 
@@ -42,10 +42,10 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: "3.10"
 
@@ -66,10 +66,10 @@ jobs:
                 python-version: [3.8, 3.9, "3.10"]  # eventually add 3.11
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v4
 
         - name: Setup Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v5
           with:
               python-version: ${{ matrix.python-version }}
 
@@ -89,10 +89,10 @@ jobs:
 #            fail-fast: true
 #
 #        steps:
-#        - uses: actions/checkout@v3
+#        - uses: actions/checkout@v4
 #
 #        - name: Setup Python
-#          uses: actions/setup-python@v4
+#          uses: actions/setup-python@v5
 #          with:
 #              python-version: "3.10"
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,18 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 24.2.0
     hooks:
       - id: black
         name: black
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.7.1
+    rev: v1.9.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests, types-setuptools, pydantic]

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -93,8 +93,7 @@ class EventABIType(ABIType):
         return sig
 
 
-class BaseABI(BaseModel):
-    ...
+class BaseABI(BaseModel): ...
 
 
 class ConstructorABI(BaseABI):

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -232,7 +232,7 @@ class Source(BaseModel):
 
         content_result = (
             {"content": Content(root={i + 1: x for i, x in enumerate(content.splitlines())})}
-            if content
+            if content is not None
             else model
         )
         return {**content_result, **other_props}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 100
+extend-ignore = E203,E701
 exclude =
 	venv*
 	.eggs

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ extras_require = {
         "hypothesis-jsonschema==0.19.0",  # Fuzzes based on a json schema
     ],
     "lint": [
-        "black>=23.11.0,<24",  # Auto-formatter and linter
-        "mypy>=1.7.1,<2",  # Static type analyzer
+        "black>=24.2.0,<25",  # Auto-formatter and linter
+        "mypy>=1.9.0,<2",  # Static type analyzer
         "types-setuptools",  # Needed for mypy type shed
         "types-requests",  # Needed for mypy type shed
-        "flake8>=6.1.0,<7",  # Style linter
+        "flake8>=7.0.0,<8",  # Style linter
         "flake8-breakpoint>=1.1.0,<2",  # Detect breakpoints left in code
         "flake8-print>=5.0.0,<6",  # Detect print statements left in code
         "isort>=5.10.1,<6",  # Import sorting linter

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ extras_require = {
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "doc": [
-        "myst-parser>=0.17.0,<0.18",  # Tools for parsing markdown files in the docs
-        "sphinx-click>=3.1.0,<4.0",  # For documenting CLI
-        "Sphinx>=4.4.0,<5.0",  # Documentation generator
-        "sphinx_rtd_theme>=1.0.0,<2",  # Readthedocs.org theme
+        "myst-parser>=2.0.0,<3",  # Tools for parsing markdown files in the docs
+        "sphinx-click>=5.1.0,<6",  # For documenting CLI
+        "Sphinx>=7.2.6,<8",  # Documentation generator
+        "sphinx_rtd_theme>=2.0.0,<3",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
     ],
     "release": [  # `release` GitHub Action job uses this

--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ extras_require = {
         "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "doc": [
-        "myst-parser>=2.0.0,<3",  # Tools for parsing markdown files in the docs
-        "sphinx-click>=5.1.0,<6",  # For documenting CLI
-        "Sphinx>=7.2.6,<8",  # Documentation generator
-        "sphinx_rtd_theme>=2.0.0,<3",  # Readthedocs.org theme
+        "myst-parser>=1.0.0,<2",  # Parse markdown docs
+        "sphinx-click>=4.4.0,<5",  # For documenting CLI
+        "Sphinx>=6.1.3,<7",  # Documentation generator
+        "sphinx_rtd_theme>=1.2.0,<2",  # Readthedocs.org theme
         "sphinxcontrib-napoleon>=0.7",  # Allow Google-style documentation
     ],
     "release": [  # `release` GitHub Action job uses this

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -241,6 +241,10 @@ def test_contract_types():
     manifest = PackageManifest(contractTypes=contract_types)
     assert manifest.contract_types == contract_types
 
+    # Show we can also set them.
+    manifest.contract_types = {}
+    assert manifest.contract_types == {}
+
 
 def test_validate_fields(package_manifest):
     """

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -327,4 +327,3 @@ def test_model_validate_empty_str():
     """
     source = Source.model_validate("")
     assert isinstance(source, Source)
-

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -316,3 +316,15 @@ def test_references():
     """
     source = Source(content="foo\n", references=["bar.txt"])
     assert source.references == ["bar.txt"]
+
+
+def test_model_validate_empty_str():
+    """
+    There was a bug where if a file was empty,
+    it would try to use the empty str as a
+    dict to create the source content, due to an improper
+    truthy check.
+    """
+    source = Source.model_validate("")
+    assert isinstance(source, Source)
+


### PR DESCRIPTION
### What I did
    There was a bug where if a file was empty,
    it would try to use the empty str as a
    dict to create the source content, due to an improper
    truthy check.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
