### PR TITLE
fix: allow mypy to detect internalType not required

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -25,7 +25,7 @@ class ABIType(BaseModel):
     Tuples and structs tend to have this field.
     """
 
-    internal_type: Optional[str] = Field(None, alias="internalType")
+    internal_type: Optional[str] = Field(default=None, alias="internalType")
     """
     Another name for the type. Sometimes, compilers are able to populate
     this field with the struct or enum name.


### PR DESCRIPTION
### What I did

Prior to this change, any downstream initializations of `ABIType` without specifying `internalType=...` in the constructor would raise the typing issue `E: Missing named argument "internalType" for "ABIType"  [call-arg]`. Changing this to a keyword arg allows mypy to correctly detect that this field is not needed.

No functional change

### How I did it

### How to verify it

I was working downstream and monkeypatched this change, and observed that mypy stopped complaining

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
~~- [ ] New test cases have been added and are passing~~
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
