### PR TITLE
feat: windows support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
             matrix:
                 # TODO: Replace with macos-latest when works again.
                 #   https://github.com/actions/setup-python/issues/808
-                os: [ubuntu-latest, macos-12]   # eventually add `windows-latest`
+                os: [ubuntu-latest, macos-12, windows-latest]
                 python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
         steps:

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -117,7 +117,7 @@ class Content(RootModel[Dict[int, str]]):
         if value is None:
             return {}
 
-        if type(value) is PosixPath:
+        if isinstance(value, Path):
             data = value.read_text()
         else:
             data = value["root"] if "_root" in value else value

--- a/ethpm_types/source.py
+++ b/ethpm_types/source.py
@@ -1,4 +1,4 @@
-from pathlib import Path, PosixPath
+from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple, Union
 
 import requests


### PR DESCRIPTION
Enables windows CI tests, uses base path type instead of posix

### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it
enabled windows CI test

### How to verify it
we'll see!

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [X] New test cases have been added and are passing
- [ ] Documentation has been updated
- [X] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
