### PR TITLE
test: re-enable `macos-latest` in CI since

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,9 +62,7 @@ jobs:
 
         strategy:
             matrix:
-                # TODO: Replace with macos-latest when works again.
-                #   https://github.com/actions/setup-python/issues/808
-                os: [ubuntu-latest, macos-12, windows-latest]
+                os: [ubuntu-latest, macos-latest, windows-latest]
                 python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
 
         steps:


### PR DESCRIPTION
### What I did

The linked issue was closed and they claim to have fixed it so giving it a whirl

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
