### PR TITLE
fix: specify encoding during `.unpack()`

### DIFF
--- a/ethpm_types/manifest.py
+++ b/ethpm_types/manifest.py
@@ -295,7 +295,7 @@ class PackageManifest(BaseModel):
             # Create nested directories as needed.
             source_path.parent.mkdir(parents=True, exist_ok=True)
 
-            source_path.write_text(content)
+            source_path.write_text(content, encoding="utf8")
 
     def get_compiler(self, name: str, version: str) -> Optional[Compiler]:
         """

--- a/tests/test_package_manifest.py
+++ b/tests/test_package_manifest.py
@@ -153,21 +153,22 @@ def test_get_contract_type(package_manifest, solidity_contract):
 
 
 def test_unpack_sources():
-    foo_txt = Content(root={0: "line 0 in foo.txt"})
-    baz_txt = Content(root={1: "line 1 in baz.txt"})
+    # NOTE: Purposely using extra utf-8 symbol `“` as an encoding test.
+    foo_txt = Content(root={0: "line “0“ in foo.txt"})
+    baz_txt = Content(root={1: "line “1“ in baz.txt"})
     sources = {"foo.txt": Source(content=foo_txt), "bar/nested/baz.txt": Source(content=baz_txt)}
     manifest = PackageManifest(sources=sources)
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        destination = Path(temp_dir) / "src"
+        destination = Path(temp_dir).resolve() / "src"
         manifest.unpack_sources(destination)
         foo_expected = destination / "foo.txt"
         baz_expected = destination / "bar" / "nested" / "baz.txt"
 
         assert foo_expected.is_file()
         assert baz_expected.is_file()
-        assert foo_expected.read_text() == str(foo_txt)
-        assert baz_expected.read_text() == str(baz_txt)
+        assert foo_expected.read_text(encoding="utf8") == str(foo_txt)
+        assert baz_expected.read_text(encoding="utf8") == str(baz_txt)
 
 
 def test_package_name_name():


### PR DESCRIPTION
### What I did

also fixes https://github.com/ApeWorX/ape/issues/2088 in a way (going back to Ape 0.7)

### How I did it

specify encoding in `write_text()`

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
