### PR TITLE
fix: handle defaults in deprecated pydantic methods

### DIFF
--- a/ethpm_types/base.py
+++ b/ethpm_types/base.py
@@ -4,31 +4,47 @@ from typing import Dict
 from pydantic import BaseModel as _BaseModel
 
 
+def _set_dict_defaults(**kwargs) -> Dict:
+    # NOTE: We do this to accommodate the aliases needed for EIP-2678 compatibility
+    if "by_alias" not in kwargs:
+        kwargs["by_alias"] = True
+
+    # EIP-2678: skip empty fields (at least by default)
+    if "exclude_none" not in kwargs:
+        kwargs["exclude_none"] = True
+
+    return kwargs
+
+
+def _to_json_str(model, *args, **kwargs) -> str:
+    # NOTE: When serializing to IPFS, the canonical representation must be repeatable
+
+    # EIP-2678: minified representation (at least by default)
+    separators = kwargs.pop("separators", (",", ":"))
+
+    # EIP-2678: sort keys (at least by default)
+    sort_keys = kwargs.pop("sort_keys", True)
+
+    # TODO: Find a better way to handle sorting the keys and custom separators.
+    #    or open an issue(s) with pydantic. `super().model_dump_json()` does not
+    #    support `sort_keys` or `separators`.
+    kwargs["by_alias"] = True
+    kwargs["mode"] = "json"
+    result_dict = model.model_dump(*args, **kwargs)
+    return json.dumps(result_dict, sort_keys=sort_keys, separators=separators)
+
+
 class BaseModel(_BaseModel):
     def model_dump(self, *args, **kwargs) -> Dict:
-        # NOTE: We do this to accommodate the aliases needed for EIP-2678 compatibility
-        if "by_alias" not in kwargs:
-            kwargs["by_alias"] = True
-
-        # EIP-2678: skip empty fields (at least by default)
-        if "exclude_none" not in kwargs:
-            kwargs["exclude_none"] = True
-
+        kwargs = _set_dict_defaults(**kwargs)
         return super().model_dump(*args, **kwargs)
 
     def model_dump_json(self, *args, **kwargs) -> str:
-        # NOTE: When serializing to IPFS, the canonical representation must be repeatable
+        return _to_json_str(self, *args, **kwargs)
 
-        # EIP-2678: minified representation (at least by default)
-        separators = kwargs.pop("separators", (",", ":"))
+    def dict(self, *args, **kwargs) -> Dict:
+        kwargs = _set_dict_defaults(**kwargs)
+        return super().dict(*args, **kwargs)
 
-        # EIP-2678: sort keys (at least by default)
-        sort_keys = kwargs.pop("sort_keys", True)
-
-        # TODO: Find a better way to handle sorting the keys and custom separators.
-        #    or open an issue(s) with pydantic. `super().model_dump_json()` does not
-        #    support `sort_keys` or `separators`.
-        kwargs["by_alias"] = True
-        kwargs["mode"] = "json"
-        result_dict = self.model_dump(*args, **kwargs)
-        return json.dumps(result_dict, sort_keys=sort_keys, separators=separators)
+    def json(self, *args, **kwargs) -> str:
+        return _to_json_str(self, *args, **kwargs)

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -22,6 +22,26 @@ class TestABIType:
         abi = ABIType(name="foo", type="tuple", components=[ABIType(name="bar", type="string")])
         assert abi.canonical_type == "(string)"
 
+    def test_model_dump(self):
+        abi = ABIType(name="foo", type="string", internalType="string")
+        actual = abi.model_dump()
+        assert actual["internalType"] == "string"
+
+    def test_dict(self):
+        abi = ABIType(name="foo", type="string", internalType="string")
+        actual = abi.dict()
+        assert actual["internalType"] == "string"
+
+    def test_model_dump_json(self):
+        abi = ABIType(name="foo", type="string", internalType="string")
+        actual = abi.model_dump_json()
+        assert "internalType" in actual
+
+    def test_json(self):
+        abi = ABIType(name="foo", type="string", internalType="string")
+        actual = abi.json()
+        assert "internalType" in actual
+
     def test_schema(self):
         actual = ABIType.model_json_schema()
         expected = {


### PR DESCRIPTION
### What I did

The deprecated `dict()` and `json()` methods did not have any of the default handlings that `model_dump()` and `model_dump_json()` did
probably should have been added when we switched to pydantic v2

fixes: #116 

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
