### PR TITLE
docs: add doc-strings for the doc-fields in `ContractType`

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -298,7 +298,16 @@ class ContractType(BaseModel):
     """
 
     userdoc: Optional[dict] = None
+    """
+    Documentation for the end-user, generated from NatSpecs
+    found in the contract source file.
+    """
+
     devdoc: Optional[dict] = None
+    """
+    Documentation for the contract maintainers, generated from NatSpecs
+    found in the contract source file.
+    """
 
     def __repr__(self) -> str:
         repr_id = self.__class__.__name__


### PR DESCRIPTION
### What I did

both userdoc and devdoc were missing docs.
I am currently trying to understand how NatSpec turns into these.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
