### PR TITLE
feat: add standard input JSON models

### DIFF
--- a/ethpm_types/standard_input.py
+++ b/ethpm_types/standard_input.py
@@ -1,0 +1,52 @@
+from ethpm_types.base import BaseModel
+from ethpm_types.source import Source
+from pydantic import Field, field_validator, ConfigDict
+
+
+class OutputSelection(BaseModel):
+    """
+    The ``outputSelection`` model of Solidity' standard input JSON.
+    """
+
+
+class Settings(BaseModel):
+    """
+    A model representing the settings-key in Solidity's defined
+    standard input JSON model.
+    """
+
+    output_selection: OutputSelection = Field(default={}, alias="outputSelection")
+    """
+    Compiler output settings per source file.
+    """
+
+    model_config = ConfigDict(extra="allow")
+    """
+    Expected extra items. Most settings are compiler-specific."
+    """
+
+
+class StandardInput(BaseModel):
+    """
+    A model representing the standard-input JSON ``solc`` expects.
+    """
+
+    language: str
+    """
+    The compiler language name, e.g. ``"Solidity"``.
+    """
+
+    sources: dict[str, Source] = {}
+    """
+    Each source needed to compile, even if not included in ``outputSelection``.
+    """
+
+    settings: Settings = Settings.model_construct({})
+    """
+    Compiler settings, such as ``evm_version``.
+    """
+
+    @field_validator("language")
+    @classmethod
+    def _validate_language(cls, value):
+        return f"{value}".capitalize()


### PR DESCRIPTION
### What I did

these models will help ape-solidity (And other projects) be able to easily create standard input json data.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
