### PR TITLE
chore: loosen pin on eth-pydantic-types

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "eth-utils>=2.1.0,<6",
         "py-cid>=0.3.0,<0.4",
         "requests>=2.32.3,<3",
-        "eth-pydantic-types>=0.1.1,<0.2",
+        "eth-pydantic-types>=0.1.0,<0.2",
     ],
     python_requires=">=3.9,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
