### PR TITLE
fix: allows event signatures with nameless parameters to be parsed

### DIFF
--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -110,7 +110,9 @@ def parse_signature(sig: str) -> tuple[str, list[tuple[str, str, str]], list[str
 
     for intup in input_tups:
         inlen = len(intup)
-        if inlen == 2:
+        if inlen == 1:
+            inputs.append((intup[0], "", ""))
+        elif inlen == 2:
             inputs.append((intup[0], "", intup[1]))
         elif inlen == 3 and intup[1] == "indexed":
             assert len(intup) == 3  # mypy more like mywhy

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -123,6 +123,24 @@ class TestEventABI:
         assert event.inputs[2].indexed is False
         assert event.inputs[2].type == "uint256"
 
+    def test_from_signature_with_nameless_param(self):
+        signature = "Transfer(address indexed from, address indexed to, uint256 value, uint)"
+        event = EventABI.from_signature(signature)
+        assert event.name == "Transfer"
+        assert event.signature == signature
+        assert event.inputs[0].name == "from"
+        assert event.inputs[0].indexed
+        assert event.inputs[0].type == "address"
+        assert event.inputs[1].name == "to"
+        assert event.inputs[1].indexed
+        assert event.inputs[1].type == "address"
+        assert event.inputs[2].name == "value"
+        assert event.inputs[2].indexed is False
+        assert event.inputs[2].type == "uint256"
+        assert event.inputs[3].name == ""
+        assert event.inputs[3].indexed is False
+        assert event.inputs[3].type == "uint"
+
     @pytest.mark.parametrize(
         "sig",
         [


### PR DESCRIPTION
### What I did

fixes: #142 
Fixes: APE-1843

### How I did it
I added accommodations for a lone type as an argument in the parsed Event signature

### How to verify it
```parse_signature('PairCreated(address indexed token0, address indexed token1, address pair, uint)')```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
