### PR TITLE
fix: unable to parse events from signatures when inputs included tuple types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     rev: 7.1.1
     hooks:
     -   id: flake8
-         additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
+        additional_dependencies: [flake8-breakpoint, flake8-print, flake8-pydantic, flake8-type-checking]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.13.0

--- a/README.md
+++ b/README.md
@@ -49,4 +49,3 @@ MethodABI(type='function', name='function_name', inputs=[...], ...)
 >>> EventABI.from_signature("Transfer(address indexed from, address indexed to, uint256 value)")
 EventABI(type='event', name='Transfer', inputs=[...], ...)
 ```
-

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -105,7 +105,8 @@ def parse_signature(sig: str) -> tuple[str, list[tuple[str, str, str]], list[str
         outputs_maybe = outsplit[1]
     index = std_sig.find("(")
     name = std_sig[:index].strip()
-    remainder = std_sig[index + 1 : -1].strip()
+    start_idx = index + 1
+    remainder = std_sig[start_idx:-1].strip()
     input_tups = [
         tuple(y.strip().split(" "))
         for y in filter(lambda x: x, [x for x in remainder.rstrip(")").split(",")])

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -126,18 +126,22 @@ def _parse_signature_inputs(abi_str: str) -> list[tuple[str, str, str]]:
     indexed = ""
     name = ""
     characters = [c for c in abi_str]
-    seen_char_since_complete = True
     working_on = "type"
     while characters:
         character = characters.pop(0)
-        if character == "," and seen_char_since_complete:
+        if character == ",":
             # We reached the end of an input, or some random space.
             result.append((type_, indexed, name))
             type_ = indexed = name = ""
-            seen_char_since_complete = False  # Avoid multiple spaces, commas causing issues.
+            working_on = "type"
+
+            # Clear random spaces.
+            while characters[0] == " ":
+                characters.pop(0)
+
             continue
 
-        elif character == " ":
+        if character == " ":
             if working_on == "type":
                 working_on = "name"
 
@@ -147,10 +151,7 @@ def _parse_signature_inputs(abi_str: str) -> list[tuple[str, str, str]]:
 
             continue
 
-        # Lets it know we can accept new types again.
-        seen_char_since_complete = True
-
-        if character == "(":
+        elif character == "(":
             # Is a tuple. Find the end of the tuple.
             type_ = "("
             end_tuple = None

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Sequence
 from enum import Enum
 from hashlib import md5, sha3_256, sha256
@@ -102,8 +103,10 @@ def parse_signature(sig: str) -> tuple[str, list[tuple[str, str, str]], list[str
     std_sig = outsplit[0]
     outputs_maybe = ""
     if len(outsplit) > 1:
-        outputs_maybe = outsplit[1]
-    name, remainder = std_sig.split("(")
+        outputs_maybe = outsplit[1] 
+    index = std_sig.find("(")
+    name = std_sig[:index].strip()
+    remainder = std_sig[index + 1 : -1].strip()
     input_tups = [
         tuple(y.strip().split(" "))
         for y in filter(lambda x: x, [x for x in remainder.rstrip(")").split(",")])

--- a/ethpm_types/utils.py
+++ b/ethpm_types/utils.py
@@ -1,5 +1,4 @@
 import json
-import re
 from collections.abc import Sequence
 from enum import Enum
 from hashlib import md5, sha3_256, sha256
@@ -103,7 +102,7 @@ def parse_signature(sig: str) -> tuple[str, list[tuple[str, str, str]], list[str
     std_sig = outsplit[0]
     outputs_maybe = ""
     if len(outsplit) > 1:
-        outputs_maybe = outsplit[1] 
+        outputs_maybe = outsplit[1]
     index = std_sig.find("(")
     name = std_sig[:index].strip()
     remainder = std_sig[index + 1 : -1].strip()

--- a/tests/test_sourcemap.py
+++ b/tests/test_sourcemap.py
@@ -16,10 +16,10 @@ def serialize(sourcemap: Iterator[SourceMapItem]) -> str:
             result += ";"
             continue
 
-        skip_start = previous_item and item.start == previous_item.start
-        skip_stop = previous_item and item.length == previous_item.length
-        skip_contract_id = previous_item and item.contract_id == previous_item.contract_id
-        skip_jump_code = previous_item and item.jump_code == previous_item.jump_code
+        skip_start = bool(previous_item and item.start == previous_item.start)
+        skip_stop = bool(previous_item and item.length == previous_item.length)
+        skip_contract_id = bool(previous_item and item.contract_id == previous_item.contract_id)
+        skip_jump_code = bool(previous_item and item.jump_code == previous_item.jump_code)
 
         if skip_jump_code and skip_contract_id and skip_stop and skip_start:
             result += ";"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from ethpm_types import EventABI
+from ethpm_types.abi import EventABIType
 from ethpm_types.utils import compute_checksum, parse_signature
 
 
@@ -13,3 +14,48 @@ def test_parse_signature():
     signature = event.signature
     actual = parse_signature(signature)
     assert actual == ("FooEvent", [], [])
+
+
+def test_parse_signature_anonymous_input():
+    ipt = EventABIType(name=None, type="uint256")
+    event = EventABI(name="FooEvent", inputs=[ipt])
+    signature = event.signature
+    actual = parse_signature(signature)
+    expected_inputs = [("uint256", "", "")]
+    assert actual == ("FooEvent", expected_inputs, [])
+
+
+def test_parse_signature_named_input():
+    ipt = EventABIType(name="bar", type="uint256")
+    event = EventABI(name="FooEvent", inputs=[ipt])
+    signature = event.signature
+    actual = parse_signature(signature)
+    expected_inputs = [("uint256", "", "bar")]
+    assert actual == ("FooEvent", expected_inputs, [])
+
+
+def test_parse_signature_indexed_input():
+    ipt = EventABIType(name="bar", type="uint256", indexed=True)
+    event = EventABI(name="FooEvent", inputs=[ipt])
+    signature = event.signature
+    actual = parse_signature(signature)
+    expected_inputs = [("uint256", "indexed", "bar")]
+    assert actual == ("FooEvent", expected_inputs, [])
+
+
+def test_parse_signature_tuple_inputs():
+    ipt = EventABIType(type="(uint256,address)")
+    event = EventABI(name="FooEvent", inputs=[ipt])
+    signature = event.signature
+    actual = parse_signature(signature)
+    expected_inputs = [("(uint256,address)", "", "")]
+    assert actual == ("FooEvent", expected_inputs, [])
+
+
+def test_parse_signature_indexed_and_named_tuple_inputs():
+    ipt = EventABIType(type="(uint256,address)", name="bartup", indexed=True)
+    event = EventABI(name="FooEvent", inputs=[ipt])
+    signature = event.signature
+    actual = parse_signature(signature)
+    expected_inputs = [("(uint256,address)", "indexed", "bartup")]
+    assert actual == ("FooEvent", expected_inputs, [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,15 @@
-from ethpm_types.utils import compute_checksum
+from ethpm_types import EventABI
+from ethpm_types.utils import compute_checksum, parse_signature
 
 
 def test_compute_checksum():
     content = b"this is content"
     actual = compute_checksum(content)
     assert actual.startswith("0x")
+
+
+def test_parse_signature():
+    event = EventABI(name="FooEvent")
+    signature = event.signature
+    actual = parse_signature(signature)
+    assert actual == ("FooEvent", [], [])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,3 +59,14 @@ def test_parse_signature_indexed_and_named_tuple_inputs():
     actual = parse_signature(signature)
     expected_inputs = [("(uint256,address)", "indexed", "bartup")]
     assert actual == ("FooEvent", expected_inputs, [])
+
+
+def test_parse_signature_multiple_inputs():
+    signature = "Transfer(address indexed from, address indexed to, uint256 value)"
+    actual = parse_signature(signature)
+    expected = (
+        "Transfer",
+        [("address", "indexed", "from"), ("address", "indexed", "to"), ("uint256", "", "value")],
+        [],
+    )
+    assert actual == expected


### PR DESCRIPTION
### What I did
Was getting the error `too many values to unpack (expected 2)` if there was a tuple in an event. This should resolve the issue of parsing the `std_sig` into more than 2 values. 
<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: https://github.com/ApeWorX/silverback/issues/178

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
