### PR TITLE
fix: was unable to generate topics when passing a list of values for a singular type

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -87,7 +87,7 @@ class EventABIType(ABIType):
         """
         The event signature.
         Will include the canonical type as well as the
-        the name if it has one. Also notes indexed types.
+        name if it has one. Also notes indexed types.
         """
 
         sig = self.canonical_type
@@ -347,7 +347,7 @@ class EventABI(BaseABI):
         ]
         return cls(name=name, inputs=input_abis)
 
-    def encode_topics(self, inputs: dict[str, Any]) -> list[Optional[str]]:
+    def encode_topics(self, inputs: dict[str, Any]) -> list[Union[Optional[str], list[str]]]:
         """
         Encode the given input data into a topics list, useful for log-filtering.
         Missing topics correspond to None values in the returns list, which work
@@ -359,7 +359,9 @@ class EventABI(BaseABI):
         Returns:
             list[Optional[str]]: Encoded topics.
         """
-        topics: list[Optional[str]] = [str(to_hex(HexBytes(keccak(text=self.selector))))]
+        topics: list[Union[Optional[str], list[str]]] = [
+            str(to_hex(HexBytes(keccak(text=self.selector))))
+        ]
         for ipt in self.inputs:
             if not ipt.indexed:
                 continue
@@ -372,10 +374,14 @@ class EventABI(BaseABI):
                 # Wildcard.
                 topics.append(None)
 
+        # Remove trailing wildcards, since they don't do anything.
+        while topics[-1] is None:
+            topics.pop()
+
         return topics
 
 
-def encode_topic_value(abi_type, value):
+def encode_topic_value(abi_type, value) -> Union[Optional[str], list[str]]:
     """
     Encode a single topic.
 
@@ -386,8 +392,12 @@ def encode_topic_value(abi_type, value):
     Returns:
         str: a hex-str of th encoded topic value.
     """
-    if isinstance(value, (list, tuple)):
-        return [encode_topic_value(abi_type, v) for v in value]
+    if value is None:
+        return None
+
+    elif isinstance(value, (list, tuple)):
+        # NOTE: Assume this is just list[str] at this point (hence type-ignore).
+        return [encode_topic_value(abi_type, v) for v in value]  # type: ignore
 
     elif is_dynamic_sized_type(abi_type):
         return encode_hex(keccak(encode_packed([str(abi_type)], [value])))

--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
 from eth_abi import grammar
-from eth_abi.abi import encode
 from eth_abi.packed import encode_packed
 from eth_pydantic_types import HashStr32, HexBytes
 from eth_utils import encode_hex, keccak, to_hex
@@ -367,7 +366,7 @@ class EventABI(BaseABI):
 
             name = getattr(ipt, "name", str(ipt))
             if name and name in inputs:
-                topic = HashStr32.__eth_pydantic_validate__(inputs[name])
+                topic = encode_topic_value(ipt.type, inputs[name])
                 topics.append(topic)
             else:
                 # Wildcard.
@@ -393,7 +392,7 @@ def encode_topic_value(abi_type, value):
     elif is_dynamic_sized_type(abi_type):
         return encode_hex(keccak(encode_packed([str(abi_type)], [value])))
 
-    return encode_hex(encode([abi_type], [value]))
+    return HashStr32.__eth_pydantic_validate__(value)
 
 
 def is_dynamic_sized_type(abi_type: Union[ABIType, str]) -> bool:

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -275,6 +275,19 @@ class TestEventABI:
         ]
         assert actual == expected
 
+    def test_encode_topics_removes_trailing_wildcards(self):
+        signature = "Transfer(address indexed from, address indexed to, uint256 indexed value)"
+        event = EventABI.from_signature(signature)
+        actual = event.encode_topics({"from": None, "to": "0x01", "value": None})
+        # The first None stays because it is not trailing. The second None is gone because
+        # it is for `.value`, which is trailing.
+        expected = [
+            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+            None,
+            "0x0000000000000000000000000000000000000000000000000000000000000001",
+        ]
+        assert actual == expected
+
 
 class TestFallbackABI:
     @pytest.mark.parametrize(

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -203,6 +203,31 @@ class TestEventABI:
         ]
         assert actual == expected
 
+    def test_encode_topics_multiple_values(self):
+        event = EventABI(
+            type="event",
+            name="FooHappened",
+            inputs=[
+                EventABIType(
+                    name="foo",
+                    type="uint256",
+                    components=None,
+                    internal_type="uint256",
+                    indexed=True,
+                )
+            ],
+            anonymous=False,
+        )
+        actual = event.encode_topics({"foo": [0, 1]})
+        expected = [
+            "0x1a7c56fae0af54ebae73bc4699b9de9835e7bb86b050dff7e80695b633f17abd",
+            [
+                "0x0000000000000000000000000000000000000000000000000000000000000000",
+                "0x0000000000000000000000000000000000000000000000000000000000000001",
+            ],
+        ]
+        assert actual == expected
+
 
 class TestFallbackABI:
     @pytest.mark.parametrize(

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -177,7 +177,6 @@ class TestEventABI:
         expected = [
             "0x36a46ac9279f9cc24a2b0ce490d205f822f91eb09330ba01a04d4b20577e469c",
             "0x000000000000000000000000c627dafb1c8c8f28fbbb560ff4d3c85f602d4a69",
-            None,
         ]
         assert actual == expected
 
@@ -186,11 +185,7 @@ class TestEventABI:
         event = EventABI.from_signature(signature)
         topics = {}
         actual = event.encode_topics(topics)
-        expected = [
-            "0x36a46ac9279f9cc24a2b0ce490d205f822f91eb09330ba01a04d4b20577e469c",
-            None,
-            None,
-        ]
+        expected = ["0x36a46ac9279f9cc24a2b0ce490d205f822f91eb09330ba01a04d4b20577e469c"]
         assert actual == expected
 
     def test_encode_topics_int(self):

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -228,6 +228,53 @@ class TestEventABI:
         ]
         assert actual == expected
 
+    def test_encode_topics_dynamic_value(self):
+        event = EventABI(
+            type="event",
+            name="FooHappened",
+            inputs=[
+                EventABIType(
+                    name="fooStr",
+                    type="string",
+                    components=None,
+                    internal_type="string",
+                    indexed=True,
+                )
+            ],
+            anonymous=False,
+        )
+        actual = event.encode_topics({"fooStr": "hello ethpm-types"})
+        expected = [
+            "0x303e54345675e954e1d04b6cc303625da54125e099e74eaa668ceebb40f49e8a",
+            "0x6bd959934a59ba145da1523272e142d1f6f9872a1bc797562e0348fc6aea9a89",
+        ]
+        assert actual == expected
+
+    def test_encode_topics_multiple_dynamic_values(self):
+        event = EventABI(
+            type="event",
+            name="FooHappened",
+            inputs=[
+                EventABIType(
+                    name="fooStr",
+                    type="string",
+                    components=None,
+                    internal_type="string",
+                    indexed=True,
+                )
+            ],
+            anonymous=False,
+        )
+        actual = event.encode_topics({"fooStr": ["hello ethpm-types", "hello apes"]})
+        expected = [
+            "0x303e54345675e954e1d04b6cc303625da54125e099e74eaa668ceebb40f49e8a",
+            [
+                "0x6bd959934a59ba145da1523272e142d1f6f9872a1bc797562e0348fc6aea9a89",
+                "0x7569d0c03843b022429ec0c9988a82a58e69908d9df2cd80c1da50bb2aee5239",
+            ],
+        ]
+        assert actual == expected
+
 
 class TestFallbackABI:
     @pytest.mark.parametrize(


### PR DESCRIPTION
### What I did

sorry, I missed this when copying over the functionality and I forgot this was a thing you could do when searching logs.
but adds back in passing in lists for single values to have a wider search

also adds in some tests for dynamic values since that was missing

also fixes an issue when passing in wildcards (None) values
also removes the trailing ones like core ape did

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
