### PR TITLE
fix: could not pass bytes for string when encoding topic

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -400,6 +400,10 @@ def encode_topic_value(abi_type, value) -> Union[Optional[str], list[str]]:
         return [encode_topic_value(abi_type, v) for v in value]  # type: ignore
 
     elif is_dynamic_sized_type(abi_type):
+        if abi_type == "string" and not isinstance(value, str):
+            # Bytes or int or something.
+            value = to_hex(value)
+
         return encode_hex(keccak(encode_packed([str(abi_type)], [value])))
 
     return HashStr32.__eth_pydantic_validate__(value)

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -307,6 +307,29 @@ class TestEventABI:
         ]
         assert actual == expected
 
+    def test_encode_topics_int_for_string(self):
+        event = EventABI(
+            type="event",
+            name="StringBytesEvent",
+            inputs=[
+                EventABIType(
+                    name="dynIndexed",
+                    type="string",
+                    components=None,
+                    internal_type=None,
+                    indexed=True,
+                ),
+            ],
+            anonymous=False,
+        )
+        data = {"dynIndexed": 123}
+        actual = event.encode_topics(data)
+        expected = [
+            "0x6168f6acac733ad1199187f85ee89781c4dfd2e625b4be24d437ec707bd1a82a",
+            "0x38848aa0a2dad98b7c8ce946459e3426193e71ee439c7b0ceb2dfb615cf41df9",
+        ]
+        assert actual == expected
+
 
 class TestFallbackABI:
     @pytest.mark.parametrize(

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -1,4 +1,5 @@
 import pytest
+from hexbytes import HexBytes
 
 from ethpm_types.abi import (
     ABIType,
@@ -280,6 +281,29 @@ class TestEventABI:
             "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
             None,
             "0x0000000000000000000000000000000000000000000000000000000000000001",
+        ]
+        assert actual == expected
+
+    def test_encode_topics_bytes_for_string(self):
+        event = EventABI(
+            type="event",
+            name="StringBytesEvent",
+            inputs=[
+                EventABIType(
+                    name="dynIndexed",
+                    type="string",
+                    components=None,
+                    internal_type=None,
+                    indexed=True,
+                ),
+            ],
+            anonymous=False,
+        )
+        data = {"dynIndexed": HexBytes(123)}
+        actual = event.encode_topics(data)
+        expected = [
+            "0x6168f6acac733ad1199187f85ee89781c4dfd2e625b4be24d437ec707bd1a82a",
+            "0x38848aa0a2dad98b7c8ce946459e3426193e71ee439c7b0ceb2dfb615cf41df9",
         ]
         assert actual == expected
 


### PR DESCRIPTION
### What I did

Didn't notice this in any core test but in my ape-boa, it came up, and I thought there was no reason not to allow this, so this fixes it.

### How I did it

detect when is not given a str for string type and hex it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
