### PR TITLE
feat(abi): add `__hash__` to BaseABI, to support set operations

### DIFF
--- a/ethpm_types/abi.py
+++ b/ethpm_types/abi.py
@@ -101,7 +101,16 @@ class EventABIType(ABIType):
         return sig
 
 
-class BaseABI(BaseModel): ...
+class BaseABI(BaseModel):
+    def __hash__(self) -> int:
+        if hasattr(self, "selector"):
+            return hash(self.selector)
+
+        elif isinstance(self, (FallbackABI, ReceiveABI)):
+            # NOTE: Essentially the same as `self.selector` since no args
+            return hash(self.signature)
+
+        raise TypeError(f"unhashable type: '{type(self)}'")
 
 
 class ConstructorABI(BaseABI):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
+skip = ["version.py"]
 
 [tool.mypy]
 exclude = ["build"]

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -95,6 +95,7 @@ class TestConstructorABI:
             inputs=[ABIType(name="contract_address", type="address", internalType="address")],
         )
         assert constructor.selector == "constructor(address)"
+        assert constructor in set((constructor, ConstructorABI()))
 
 
 class TestEventABI:
@@ -108,6 +109,7 @@ class TestEventABI:
     def test_selector(self):
         event = EventABI(name="FooEvent")
         assert event.selector == "FooEvent()"
+        assert event in set((event, EventABI(name="BarEvent")))
 
     def test_from_signature(self):
         signature = "Transfer(address indexed from, address indexed to, uint256 value)"
@@ -361,6 +363,7 @@ class TestMethodABI:
             ],
         )
         assert abi.selector == "MyMethod(address,string)"
+        assert abi in set((abi, MethodABI(name="OtherMethod")))
 
     def test_from_signature(self):
         signature = "transfer(address to, uint256 value)"


### PR DESCRIPTION
### What I did

Helps fix https://github.com/ApeWorX/ape/issues/2566

### How I did it

### How to verify it

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
~~- [ ] Documentation has been updated~~
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
