### PR TITLE
fix: missing `extend()` method on `contract_type.abis`

### DIFF
--- a/ethpm_types/contract_type.py
+++ b/ethpm_types/contract_type.py
@@ -250,6 +250,10 @@ class ABIList(RootModel[list[ABILIST_T]]):
         # Returning `NotImplemented` constant to try from other side (not an error).
         return NotImplemented
 
+    def extend(self, abis: Iterable[Union[ABI, "ABIList"]]) -> None:
+        other_abis = getattr(abis, "root", abis)
+        self.root.extend(other_abis)
+
     def get(self, item, default: Optional[ABILIST_T] = None) -> Optional[ABILIST_T]:
         return self[item] if item in self else default
 

--- a/tests/test_abi.py
+++ b/tests/test_abi.py
@@ -423,3 +423,15 @@ class TestABIList:
         # Show the .get() method works.
         actual = abi_ls.get("transfer")
         assert actual.signature == signature
+
+    def test_extend(self):
+        abi1 = MethodABI.from_signature("transfer(address to, uint256 value)")
+        abi2 = MethodABI.from_signature("transferFrom(address from, uint256 value)")
+        abi3 = MethodABI.from_signature("transferNow(address someone, uint256 value)")
+        abi_ls = ABIList((abi1,))
+        abi_ls.extend((abi2,))
+        abi_ls.extend(ABIList((abi3,)))
+        assert len(abi_ls) == 3
+        assert abi_ls[abi1.selector] == abi1
+        assert abi_ls[abi2.selector] == abi2
+        assert abi_ls[abi3.selector] == abi3


### PR DESCRIPTION
### What I did

unpublished bugfix, used by `ape-tokens`, need the extend method

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
